### PR TITLE
Improve performance by removing redundant legal play checks

### DIFF
--- a/lib/hearts/hearts_ai.dart
+++ b/lib/hearts/hearts_ai.dart
@@ -417,11 +417,6 @@ MonteCarloResult chooseCardMonteCarlo(
 
 void doRollout(HeartsRound round, ChooseCardFn chooseFn, Random rng) {
   while (!round.isOver()) {
-    final legalPlays = round.legalPlaysForCurrentPlayer();
-    if (legalPlays.isEmpty) {
-      final msg = "No legal plays for ${round.currentPlayerIndex()}";
-      throw Exception(msg);
-    }
     // CardToPlayRequest.fromRound makes deep copies of HeartsRound fields,
     // which is safe but expensive. Here we can just copy the references,
     // because we know the round won't be modified during the lifetime of `req`.

--- a/lib/ohhell/ohhell_ai.dart
+++ b/lib/ohhell/ohhell_ai.dart
@@ -348,11 +348,6 @@ MonteCarloResult chooseCardMonteCarlo(
 
 void doRollout(OhHellRound round, ChooseCardFn chooseFn, Random rng) {
   while (!round.isOver()) {
-    final legalPlays = round.legalPlaysForCurrentPlayer();
-    if (legalPlays.isEmpty) {
-      final msg = "No legal plays for ${round.currentPlayerIndex()}";
-      throw Exception(msg);
-    }
     final req = CardToPlayRequest.fromRoundWithSharedReferences(round);
     final cardToPlay = chooseFn(req, rng);
     round.playCard(cardToPlay);

--- a/lib/spades/spades_ai.dart
+++ b/lib/spades/spades_ai.dart
@@ -655,11 +655,6 @@ MonteCarloResult chooseCardMonteCarlo(
 void doRollout(SpadesRound round, ChooseCardFn chooseFn, Random rng) {
   final bids = [...round.players.map((p) => p.bid!)];
   while (!round.isOver()) {
-    final legalPlays = round.legalPlaysForCurrentPlayer();
-    if (legalPlays.isEmpty) {
-      final msg = "No legal plays for ${round.currentPlayerIndex()}";
-      throw Exception(msg);
-    }
     // CardToPlayRequest.fromRound makes deep copies of HeartsRound fields,
     // which is safe but expensive. Here we can just copy the references,
     // because we know the round won't be modified during the lifetime of `req`.


### PR DESCRIPTION
If there are no legal plays (which should never happen) the card choosing functions will throw exceptions, so the separate check isn't necessary. This seems to reduce the Monte Carlo evaluation time by 10-20%.