### PR TITLE
More bidding fixes

### DIFF
--- a/lib/bridge/sayc/README.md
+++ b/lib/bridge/sayc/README.md
@@ -231,9 +231,10 @@ consulted.
   than advanced. Advances never jump past game; a takeout double is
   answered in the best unbid suit (0-8 cheap, 9-11 jump, 12+ game);
   overcalls are raised with 3+ support on the 6-10/11-12/13+ ladder (13+
-  raises a minor overcall to 5m when notrump lacks a stopper), and 3NT
-  needs only 12 opposite a sound overcall of a preempt; systems on over
-  partner's 1NT overcall.
+  without a stopper for notrump raises a minor overcall to 5m with 4+
+  support, or jump-raises as a stopgap with only three — no cue-bid
+  advances yet), and 3NT needs only 12 opposite a sound overcall of a
+  preempt; systems on over partner's 1NT overcall.
 - Responder over an overcall: raises keep their uncontested meanings (major
   raises take priority over a negative double); negative doubles show 4+
   cards in the unbid major (exactly four at the one level — with five, bid

--- a/lib/bridge/sayc/README.md
+++ b/lib/bridge/sayc/README.md
@@ -230,8 +230,9 @@ consulted.
   trumps (5+ HCP among them) and 8+ HCP, the double is converted rather
   than advanced. Advances never jump past game; a takeout double is
   answered in the best unbid suit (0-8 cheap, 9-11 jump, 12+ game);
-  overcalls are raised with 3+ support on the 6-10/11-12/13+ ladder, and
-  3NT needs only 12 opposite a sound overcall of a preempt; systems on over
+  overcalls are raised with 3+ support on the 6-10/11-12/13+ ladder (13+
+  raises a minor overcall to 5m when notrump lacks a stopper), and 3NT
+  needs only 12 opposite a sound overcall of a preempt; systems on over
   partner's 1NT overcall.
 - Responder over an overcall: raises keep their uncontested meanings (major
   raises take priority over a negative double); negative doubles show 4+

--- a/lib/bridge/sayc/README.md
+++ b/lib/bridge/sayc/README.md
@@ -157,7 +157,9 @@ consulted.
   a limit raise with 14+).
 - After Jacoby 2NT: 4M minimum, 3M with extras.
 - After 1NT openings: Stayman answers (2D/2H/2S, hearts first with both),
-  transfer completions, invitation accepted with 16+. After 2NT openings the
+  transfer completions, invitation accepted with 16+; the post-transfer 2NT
+  invite is accepted with any 4 trumps (9-card fit), and a minimum with 3
+  trumps declines into 3M rather than passing. After 2NT openings the
   same structures one level higher (3D/3H/3S Stayman answers, transfer
   completions); responder continues game-going (raise the found fit, 3NT
   choice-of-games with five, 4M with six) and opener corrects with a fit.

--- a/lib/bridge/sayc/README.md
+++ b/lib/bridge/sayc/README.md
@@ -232,9 +232,11 @@ consulted.
   answered in the best unbid suit (0-8 cheap, 9-11 jump, 12+ game);
   overcalls are raised with 3+ support on the 6-10/11-12/13+ ladder (13+
   without a stopper for notrump raises a minor overcall to 5m with 4+
-  support, or jump-raises as a stopgap with only three — no cue-bid
-  advances yet), and 3NT needs only 12 opposite a sound overcall of a
-  preempt; systems on over partner's 1NT overcall.
+  support; with only three, a cue bid of their suit shows a limit raise
+  or better and the overcaller chooses 3NT with a stopper, signs off at
+  the cheapest level with a minimum, or raises to game with 13+), and
+  3NT needs only 12 opposite a sound overcall of a preempt; systems on
+  over partner's 1NT overcall.
 - Responder over an overcall: raises keep their uncontested meanings (major
   raises take priority over a negative double); negative doubles show 4+
   cards in the unbid major (exactly four at the one level — with five, bid

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -4144,9 +4144,21 @@ List<SaycRule>? advanceOvercallRules(
         suitLengths: {suit: const Range(low: 4)},
       ),
     ));
-    // Only three trumps and no stopper: jump raise as a stopgap (a cue bid
-    // would be the textbook call, but that machinery doesn't exist yet).
-    if (raiseLevel + 1 < 5) {
+    // Only three trumps and no stopper: cue-bid their suit (limit raise
+    // or better) so the overcaller can choose 3NT with a stopper.
+    final cueLevel = theirSuit != null ? cheapestLevel(theirSuit, over) : 99;
+    if (theirSuit != null && cueLevel <= 3) {
+      rules.add(SaycRule(
+        BidAction.contract(cueLevel, theirSuit),
+        BidMeaning(
+          description: "Cue bid: raise of $name, game values",
+          totalPoints: const Range(low: 13),
+          suitLengths: {suit: const Range(low: 3)},
+          artificial: true,
+        ),
+      ));
+    } else if (raiseLevel + 1 < 5) {
+      // No cue available: jump raise as a stopgap.
       rules.add(SaycRule(
         BidAction.contract(raiseLevel + 1, suit),
         BidMeaning(
@@ -4159,6 +4171,49 @@ List<SaycRule>? advanceOvercallRules(
   }
   rules.add(SaycRule(BidAction.pass(),
       BidMeaning(description: "No suitable advance of the overcall")));
+  return rules;
+}
+
+/// Overcaller's rebid after partner cue-bids the opponents' suit (a limit
+/// raise or better of the overcall). The cue is forcing: with a stopper in
+/// their suit choose 3NT, with extras raise to game, otherwise sign off in
+/// the overcalled suit. [forced] is false when an opponent bid over the cue.
+List<SaycRule> overcallCueRebidRules(ContractBid theirOpening,
+    ContractBid overcall, ContractBid over, bool forced) {
+  final suit = overcall.trump!;
+  final name = _suitNames[suit]!;
+  final theirSuit = theirOpening.trump;
+  final gameCount = _isMajor(suit) ? 4 : 5;
+  final rules = <SaycRule>[];
+  if (theirSuit != null && cheapestLevel(null, over) <= 3) {
+    rules.add(SaycRule(
+      BidAction.noTrump(3),
+      BidMeaning(
+          description: "Game in notrump: ${_suitNames[theirSuit]} stopped",
+          totalPoints: const Range(low: 12)),
+      ignoreInfo: true,
+      require: (h) => h.totalPoints >= 12 && h.hasStopper(theirSuit),
+    ));
+  }
+  final level = cheapestLevel(suit, over);
+  if (level <= gameCount) {
+    rules.add(SaycRule(
+      BidAction.contract(gameCount, suit),
+      BidMeaning(
+          description: "Game raise: extra values opposite the cue bid",
+          totalPoints: const Range(low: 13)),
+    ));
+  }
+  if (forced && level <= gameCount) {
+    rules.add(SaycRule(
+      BidAction.contract(level, suit),
+      BidMeaning(description: "Minimum overcall: signing off in $name"),
+      ignoreInfo: true,
+    ));
+  } else {
+    rules.add(SaycRule(BidAction.pass(),
+        BidMeaning(description: "Nothing more to say over the cue bid")));
+  }
   return rules;
 }
 
@@ -5059,6 +5114,27 @@ List<SaycRule>? saycRulesForAuction(List<BidAction> calls) {
       }
       if (action.bidType == BidType.contract) {
         return advanceOvercallRules(openBid, action.contractBid!, last);
+      }
+    }
+    if (myActions.length == 1 &&
+        partnerActions.length == 1 &&
+        oppActions.length <= 3 &&
+        isSuitBid(myActions[0]) &&
+        openBid.trump != null &&
+        partnerActions[0].bidType == BidType.contract &&
+        partnerActions[0].contractBid!.trump == openBid.trump) {
+      // Partner cue-bid the opponents' suit over my overcall.
+      final cue = partnerActions[0].contractBid!;
+      ContractBid? last;
+      for (int i = n - 1; i >= 0; i--) {
+        if (calls[i].bidType == BidType.contract) {
+          last = calls[i].contractBid;
+          break;
+        }
+      }
+      if (last != null) {
+        return overcallCueRebidRules(
+            openBid, myActions[0].contractBid!, last, last == cue);
       }
     }
     return null;

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -4144,6 +4144,18 @@ List<SaycRule>? advanceOvercallRules(
         suitLengths: {suit: const Range(low: 4)},
       ),
     ));
+    // Only three trumps and no stopper: jump raise as a stopgap (a cue bid
+    // would be the textbook call, but that machinery doesn't exist yet).
+    if (raiseLevel + 1 < 5) {
+      rules.add(SaycRule(
+        BidAction.contract(raiseLevel + 1, suit),
+        BidMeaning(
+          description: "Jump raise: 3 $name, game values, no stopper",
+          totalPoints: const Range(low: 13),
+          suitLengths: {suit: const Range(low: 3)},
+        ),
+      ));
+    }
   }
   rules.add(SaycRule(BidAction.pass(),
       BidMeaning(description: "No suitable advance of the overcall")));

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -3232,7 +3232,15 @@ List<SaycRule> _oneNtOpenerThirdRules(
         SaycRule(
           BidAction.contract(4, major),
           BidMeaning(
-            description: "Maximum with 3+ $name",
+            description: "Accepting with four $name: 9-card fit",
+            hcp: const Range(low: 15, high: 17),
+            suitLengths: {major: const Range(low: 4)},
+          ),
+        ),
+        SaycRule(
+          BidAction.contract(4, major),
+          BidMeaning(
+            description: "Maximum with 3 $name",
             hcp: const Range(low: 16, high: 17),
             suitLengths: {major: const Range(low: 3, high: 5)},
           ),
@@ -3244,9 +3252,18 @@ List<SaycRule> _oneNtOpenerThirdRules(
               hcp: const Range(low: 16, high: 17)),
         ),
         SaycRule(
+          BidAction.contract(3, major),
+          BidMeaning(
+            description: "Minimum, but 3 $name: the 5-3 fit plays better",
+            hcp: const Range(low: 15, high: 15),
+            suitLengths: {major: const Range(low: 3, high: 3)},
+          ),
+        ),
+        SaycRule(
           BidAction.pass(),
           BidMeaning(
-              description: "Minimum", hcp: const Range(low: 15, high: 15)),
+              description: "Minimum, no fit",
+              hcp: const Range(low: 15, high: 15)),
         ),
       ];
     }

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -4134,6 +4134,17 @@ List<SaycRule>? advanceOvercallRules(
       require: stopperOk,
     ));
   }
+  if (!_isMajor(suit) && cheapestLevel(suit, over) <= 5) {
+    // Game values but no stopper for notrump: raise the minor to game.
+    rules.add(SaycRule(
+      BidAction.contract(5, suit),
+      BidMeaning(
+        description: "Raise to game: 4+ $name, 13+ points",
+        totalPoints: const Range(low: 13),
+        suitLengths: {suit: const Range(low: 4)},
+      ),
+    ));
+  }
   rules.add(SaycRule(BidAction.pass(),
       BidMeaning(description: "No suitable advance of the overcall")));
   return rules;

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1056,9 +1056,23 @@ void main() {
       // Same shape with a stopper prefers notrump.
       expect(openingBid("A2", "A32", "32", "AQJ432", history: h), "3NT");
       expect(openingBid("2", "A32", "432", "AQJ432", history: h), "2NT");
-      // 13+ with only three trumps and no stopper: jump raise as a stopgap
-      // (a cue bid would be the textbook call).
-      expect(openingBid("AK32", "432", "A32", "Q32", history: h), "4C");
+      // 13+ with only three trumps and no stopper: cue bid their suit
+      // (limit raise or better).
+      expect(openingBid("AK32", "432", "A32", "Q32", history: h), "3H");
+    });
+
+    test("overcaller after partner's cue bid", () {
+      final h = ["1H", "2C", "2H", "3H", "pass"];
+      // With their suit stopped, choose 3NT.
+      expect(openingBid("K2", "KJ2", "32", "KQT943", history: h), "3NT");
+      // Minimum, no stopper: sign off (never pass the forcing cue).
+      expect(openingBid("KQ2", "432", "2", "KQT943", history: h), "4C");
+      // Extra values, no stopper: game in the minor.
+      expect(openingBid("AQ2", "32", "A2", "KQJ943", history: h), "5C");
+      // Opener bidding over the cue relieves the force but not the values.
+      final contested = ["1H", "2C", "2H", "3H", "4H"];
+      expect(openingBid("AQ2", "32", "A2", "KQJ943", history: contested), "5C");
+      expect(openingBid("KQ2", "432", "2", "KQT943", history: contested), "Pass");
     });
 
     test("free advances are not forced", () {

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1056,6 +1056,9 @@ void main() {
       // Same shape with a stopper prefers notrump.
       expect(openingBid("A2", "A32", "32", "AQJ432", history: h), "3NT");
       expect(openingBid("2", "A32", "432", "AQJ432", history: h), "2NT");
+      // 13+ with only three trumps and no stopper: jump raise as a stopgap
+      // (a cue bid would be the textbook call).
+      expect(openingBid("AK32", "432", "A32", "Q32", history: h), "4C");
     });
 
     test("free advances are not forced", () {

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1073,6 +1073,10 @@ void main() {
       final contested = ["1H", "2C", "2H", "3H", "4H"];
       expect(openingBid("AQ2", "32", "A2", "KQJ943", history: contested), "5C");
       expect(openingBid("KQ2", "432", "2", "KQT943", history: contested), "Pass");
+      // Opponent doubling the cuebid is treated the same as a pass.
+      final doubled = ["1H", "2C", "2H", "3H", "X"];
+      expect(openingBid("AQ2", "32", "A2", "KQJ943", history: doubled), "5C");
+      expect(openingBid("KQ2", "432", "2", "KQT943", history: doubled), "4C");
     });
 
     test("free advances are not forced", () {
@@ -1470,7 +1474,17 @@ void main() {
     test("transfer invitation decisions", () {
       final invite = ["1NT", "pass", "2D", "pass", "2H", "pass", "2NT", "pass"];
       expect(openingBid("K32", "A32", "AQ32", "KJ2", history: invite), "4H");
-      expect(openingBid("K32", "A32", "AQ32", "Q32", history: invite), "Pass");
+      // Four trumps accept even at a minimum: 9-card fit, ruffing values.
+      expect(openingBid("K32", "A432", "AQ32", "Q2", history: invite), "4H");
+      // A minimum with three trumps declines into 3H, not 2NT.
+      expect(openingBid("K32", "A32", "AQ32", "Q32", history: invite), "3H");
+      expect(openingBid("K32", "A3", "AQ32", "Q432", history: invite), "Pass");
+      expect(openingBid("KQ2", "A3", "AQ32", "Q432", history: invite), "3NT");
+      expect(
+          openingBid("AQ87", "A8", "QT63", "K64",
+              history: ["1NT", "pass", "2H", "pass", "2S", "pass", "2NT",
+                  "pass"]),
+          "4S");
     });
   });
 

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1049,6 +1049,15 @@ void main() {
           "2S"); // free advance over their raise
     });
 
+    test("strong advance of a minor overcall", () {
+      final h = ["1H", "2C", "2H"];
+      // 13+ with a big fit and no heart stopper: game in the minor.
+      expect(openingBid("A2", "32", "432", "AQJ432", history: h), "5C");
+      // Same shape with a stopper prefers notrump.
+      expect(openingBid("A2", "A32", "32", "AQJ432", history: h), "3NT");
+      expect(openingBid("2", "A32", "432", "AQJ432", history: h), "2NT");
+    });
+
     test("free advances are not forced", () {
       expect(openingBid("KQ32", "432", "K432", "32", history: ["1H", "X", "2H"]),
           "2S");


### PR DESCRIPTION
- Improve responses to minor overcalls (raise to 4 or 5 with a strong fit and no stopper, cuebid with limit raise or better and 3 card support)
- Improve reponses to 2NT after Jacoby transfers (bid 3H/3S with minimum hand and 3 trumps, always accept game with 4+ trumps)