### PR TITLE
Improve bridge AI play by always doing full double dummy solves

### DIFF
--- a/lib/bridge/PLAY_AI.md
+++ b/lib/bridge/PLAY_AI.md
@@ -146,11 +146,40 @@ boards; dd=7 measured +0.5 to +0.8 pooled across seeds). Moral: with
 200-300+ boards to resolve. If a low-end device needs a cheaper config,
 cut `maxRounds` before cutting `ddTricksLimit`.
 
+## The honor-waste guard
+
+Double-dummy evaluation is blind to the main real-world cost of leading
+an unsupported high honor: every sampled declarer already knows where it
+is, so the lead is rarely punished and sometimes shows a small spurious
+edge that a non-clairvoyant declarer would never realize (the classic
+GIB-family artifact — `scripts/lead_scan.dart` measured unsupported K/Q
+leads on ~7% of defender leads, several into a higher visible dummy
+honor). When the equity-best play is a lead of an effectively
+unsupported K or Q with a lower card available, MCDD now leads low from
+the same suit instead, unless the honor is decisively better: by more
+than a margin (5 points/deal for declarer, 18 for defenders, whose honor
+locations are the ones DD leaks) AND by a statistically significant
+paired difference across the sampled deals. Genuine coups clear that bar
+(verified examples: cashing a king before dummy's ace gets ruffed;
+leading Q from QT65 to pin dummy's singleton jack) and are still made.
+
+Calibration was delicate and measured (200 boards each):
+- Broadly preferring the heuristic's card on any near-tie: -0.86 IMPs/bd.
+- Guard deferring to the heuristic's (cross-suit) lead: -0.32.
+- Guard deferring to low card of the same suit: **-0.10 +/- 0.16** (zero),
+  while cutting flagged unsupported-honor leads by ~75% at 10 sampled
+  deals (and ~40% at 50, where survivors have decisive DD support).
+
+Lesson: suppress only the exact artifact pattern and keep the sampling
+engine's suit selection; every broader deferral to conventional play
+costs measurable equity.
+
 ## Known limitations / future ideas
 
 - Double-dummy defenders "see" declarer's cards within each sampled deal
   (standard for this architecture); genuinely deceptive plays are neither
-  made nor anticipated.
+  made nor anticipated. The honor-waste guard above patches the most
+  visible symptom; second-hand and discard honor waste are not guarded.
 - The solver could be pushed further with partition search or
   finer-grained quick-trick bounds (partner entries, ruff counting);
   that would let the preroll boundary move later.

--- a/lib/bridge/PLAY_AI.md
+++ b/lib/bridge/PLAY_AI.md
@@ -209,6 +209,10 @@ deals on slow devices). At the app configuration (2.2s budget) the win
 holds: +1.03 +/- 0.59 IMPs/board (60 boards, 24-7-29), with average
 play time ~415ms on a desktop M4.
 
+With full-depth solving, the engine's direct margin over an MC with
+maxtricks rollouts (the strongest pre-project baseline) is
+**+2.07 +/- 0.27 IMPs/board** (300 boards, seed 21, 156-48-96).
+
 ## Known limitations / future ideas
 
 - Double-dummy defenders "see" declarer's cards within each sampled deal

--- a/lib/bridge/PLAY_AI.md
+++ b/lib/bridge/PLAY_AI.md
@@ -20,11 +20,14 @@ Card play is Monte Carlo over hidden information, in three layers:
    whose gaps have all been played) evaluate as a single candidate, the
    cheapest of the group.
 3. **Evaluation** (`chooseCardMonteCarloDD`): each candidate play is tried
-   on each sampled deal; the position is played forward with the cheap
-   heuristic policy until at most K tricks remain (default 8), and the
-   remainder is solved *exactly* with the double-dummy solver. The
-   declarer's total tricks convert to a contract score, averaged across
-   deals. Exact equity ties break toward the lowest card.
+   on each sampled deal and the resulting position is solved *exactly*
+   with the double-dummy solver, to full depth when a node budget allows
+   (the usual case); positions too complex for that are played forward
+   with the cheap heuristic policy until at most K tricks remain (default
+   8) and solved from there. The declarer's total tricks convert to a
+   contract score, averaged across deals. Exact equity ties break toward
+   the lowest card, and an honor-waste guard (below) filters one class of
+   double-dummy artifact from chosen leads.
 
 ### The double-dummy solver (`dd_solver.dart`)
 
@@ -60,8 +63,11 @@ policy for MCDD and is available standalone as the `heuristic` strategy.
 bid once by the SAYC engine, then played in two rooms with the strategies'
 sides swapped, and scored by IMPs exactly as a team-of-four match. Both
 rooms share RNG seeds (common random numbers), so identical strategies
-score exactly zero and shared noise cancels. Strategy specs are documented
-in `play_strategies.dart`:
+score exactly zero and shared noise cancels. Boards run in parallel
+across isolates (`--jobs`, default cores-2); randomness is seeded per
+board, so results are identical for any job count. Per-play timing stats
+inflate slightly under contention — calibrate app budgets with
+`--jobs 1`. Strategy specs are documented in `play_strategies.dart`:
 
     dart run scripts/bridge_play_compare.dart --deals 100 \
         mcdd:rounds=10:dd=7 mc:rollout=random:rounds=20:rpr=10
@@ -89,6 +95,10 @@ inference.
 | MCDD dd=6 vs dd=7, equal rounds, 300 boards seed 43 | 300 | **-0.73 +/- 0.27** |
 | MCDD dd=7 vs maxtricks MC, seed 43 | 200 | +0.47 +/- 0.33 |
 | MCDD dd=6 vs maxtricks MC, seed 43 | 200 | -0.11 +/- 0.34 |
+| honor-waste guard (final form) vs no guard, seed 11 | 200 | +0.05 +/- 0.20 |
+| full-depth solving vs preroll-only, seed 11 | 200 | **+1.27 +/- 0.30** |
+| full-depth vs preroll-only at app config (2.2s), seed 5 | 60 | +1.03 +/- 0.59 |
+| **final engine vs maxtricks MC, seed 21** | 300 | **+2.07 +/- 0.27** |
 
 Two negative results shaped the final design:
 
@@ -128,14 +138,15 @@ also never wastes an honor between equals.
 ## App configuration
 
 `computeCard` in `bridge_ui.dart` runs `chooseCardMonteCarloDD` with up
-to 50 sampled deals, double-dummy solving from 7 tricks out, and a 2.2s
-time budget (the old Monte Carlo remains as a defensive fallback). It
-beat the previously shipped configuration by +2.83 +/- 1.00 IMPs/board
-(12 boards, 8 wins 1 loss 3 ties) and averages ~150ms per play (max
-~2.2s) on a desktop M4. The budget is enforced between candidates as
-well as between sampled deals, so slow devices degrade to fewer sampled
-deals rather than longer thinks; if no sampled deal completes at all,
-the move falls back to the heuristic policy.
+to 50 sampled deals, full-depth solving where affordable (preroll from
+7 tricks out otherwise), and a 2.2s time budget (the old Monte Carlo
+remains as a defensive fallback). The original MCDD configuration beat
+the previously shipped one by +2.83 +/- 1.00 IMPs/board; with
+full-depth solving, average play time is ~415ms (max ~2.4s) on a
+desktop M4. The budget is enforced between candidates as well as
+between sampled deals, so slow devices degrade to fewer sampled deals
+rather than longer thinks; if no sampled deal completes at all, the
+move falls back to the heuristic policy.
 
 dd=6 was tried as a ~4x cheaper alternative and initially looked like a
 wash in 100-board comparisons, but a 300-board head-to-head measured it

--- a/lib/bridge/PLAY_AI.md
+++ b/lib/bridge/PLAY_AI.md
@@ -236,6 +236,12 @@ maxtricks rollouts (the strongest pre-project baseline) is
 - Deal sampling is rejection-based; heavily constrained auctions
   occasionally fall back to best-effort samples. Weighted dealing (deal
   honors to fit HCP windows directly) would raise the hit rate.
+- Deal sampling draws no inference from opponents' *card choices* (only
+  bids and shown voids). E.g. in the weird_duck_check position, a human
+  reads West's ace-then-low continuation for the location of the jack;
+  the sampler keeps it 50/50, which is exactly why the duck-vs-win
+  equities there are nearly tied. Weighting layouts by the plausibility
+  of the observed defensive carding would be the next inference layer.
 - Opening leads are made before dummy is visible with no bidding-free
   information; lead conventions live in the heuristic policy, not MCDD
   candidates.

--- a/lib/bridge/PLAY_AI.md
+++ b/lib/bridge/PLAY_AI.md
@@ -155,24 +155,28 @@ edge that a non-clairvoyant declarer would never realize (the classic
 GIB-family artifact — `scripts/lead_scan.dart` measured unsupported K/Q
 leads on ~7% of defender leads, several into a higher visible dummy
 honor). When the equity-best play is a lead of an effectively
-unsupported K or Q with a lower card available, MCDD now leads low from
-the same suit instead, unless the honor is decisively better: by more
-than a margin (5 points/deal for declarer, 18 for defenders, whose honor
-locations are the ones DD leaks) AND by a statistically significant
-paired difference across the sampled deals. Genuine coups clear that bar
-(verified examples: cashing a king before dummy's ace gets ruffed;
-leading Q from QT65 to pin dummy's singleton jack) and are still made.
+unsupported K or Q with a lower card available, MCDD instead plays the
+best-scoring candidate that doesn't match that pattern, unless the honor
+is decisively better: by more than a margin (5 points/deal for declarer,
+18 for defenders, whose honor locations are the ones DD leaks) AND by a
+statistically significant paired difference across the sampled deals.
+Genuine coups clear that bar (verified examples: cashing a king before
+dummy's ace gets ruffed; leading Q from QT65 to pin dummy's singleton
+jack) and are still made.
 
 Calibration was delicate and measured (200 boards each):
 - Broadly preferring the heuristic's card on any near-tie: -0.86 IMPs/bd.
 - Guard deferring to the heuristic's (cross-suit) lead: -0.32.
-- Guard deferring to low card of the same suit: **-0.10 +/- 0.16** (zero),
-  while cutting flagged unsupported-honor leads by ~75% at 10 sampled
-  deals (and ~40% at 50, where survivors have decisive DD support).
+- Guard deferring to low card of the same suit: -0.10 +/- 0.16, cutting
+  flagged unsupported-honor leads ~75% at 10 sampled deals, ~40% at 50.
+- Guard deferring to the next-best-scoring non-artifact candidate:
+  **+0.05 +/- 0.20** (exactly free), cutting flagged leads 100% at 10
+  sampled deals and ~67% at 50 (the survivors carry decisive DD edges
+  over every alternative). Shipped.
 
-Lesson: suppress only the exact artifact pattern and keep the sampling
-engine's suit selection; every broader deferral to conventional play
-costs measurable equity.
+Lesson: suppress only the exact artifact pattern and fall back along the
+measured-equity ranking, not to conventional play; every deferral to the
+heuristic's judgment costs measurable equity.
 
 ## Known limitations / future ideas
 

--- a/lib/bridge/PLAY_AI.md
+++ b/lib/bridge/PLAY_AI.md
@@ -205,7 +205,9 @@ rounds=50 lead scan drops to near-baseline (10 flags, 4 against the
 heuristic's judgment), and the poster-child "genuine coup" K-from-K2
 lead is re-ranked from best to worst. Average play cost rose from ~22ms
 to ~214ms at rounds=10 (the app's 2.2s budget copes by sampling fewer
-deals on slow devices).
+deals on slow devices). At the app configuration (2.2s budget) the win
+holds: +1.03 +/- 0.59 IMPs/board (60 boards, 24-7-29), with average
+play time ~415ms on a desktop M4.
 
 ## Known limitations / future ideas
 

--- a/lib/bridge/PLAY_AI.md
+++ b/lib/bridge/PLAY_AI.md
@@ -160,9 +160,11 @@ best-scoring candidate that doesn't match that pattern, unless the honor
 is decisively better: by more than a margin (5 points/deal for declarer,
 18 for defenders, whose honor locations are the ones DD leaks) AND by a
 statistically significant paired difference across the sampled deals.
-Genuine coups clear that bar (verified examples: cashing a king before
-dummy's ace gets ruffed; leading Q from QT65 to pin dummy's singleton
-jack) and are still made.
+Genuine coups clear that bar and are still made. (Caution from later
+work: several "decisive" honor leads that survived this guard —
+including one confidently rationalized as a cash before a ruff — turned
+out to be preroll-bias artifacts, exposed and fixed by full-depth
+solving below.)
 
 Calibration was delicate and measured (200 boards each):
 - Broadly preferring the heuristic's card on any near-tie: -0.86 IMPs/bd.
@@ -177,6 +179,33 @@ Calibration was delicate and measured (200 boards each):
 Lesson: suppress only the exact artifact pattern and fall back along the
 measured-equity ranking, not to conventional play; every deferral to the
 heuristic's judgment costs measurable equity.
+
+## Full-depth solving (preroll bias)
+
+A reported oddity (dummy ducking with a master K-x behind it, in a
+cold 4S) exposed a deeper evaluation bug: prerolling with the heuristic
+policy before the endgame solve re-introduces follow-up competence bias
+in miniature. A candidate whose continuation the heuristic misplays
+during the preroll window (e.g. cashing away a tenace instead of
+finessing) is systematically undervalued — enough to invert decisions.
+An exact per-layout audit (`scripts/weird_duck_check.dart`) showed MCDD
+preferring the duck by ~30 points/deal while true double-dummy said
+winning the K was better; the entire gap was preroll misplay in the
+win-the-K branch.
+
+Fix: try to solve each candidate position to *full depth* first (the
+solver's quick-trick bounds make this 5-50ms in most positions); only
+when a solve exceeds a ~1.5M-node budget does the call fall back to
+preroll-then-solve, and then consistently for all remaining deals.
+Measured impact at equal sampled deals: **+1.27 +/- 0.30 IMPs/board**
+(200 boards, 79-34-87) — the preroll bias had been costing more than an
+IMP per board. It also turned out to be the true source of most
+"decisive" unsupported-honor leads: with full-depth evaluation the
+rounds=50 lead scan drops to near-baseline (10 flags, 4 against the
+heuristic's judgment), and the poster-child "genuine coup" K-from-K2
+lead is re-ranked from best to worst. Average play cost rose from ~22ms
+to ~214ms at rounds=10 (the app's 2.2s budget copes by sampling fewer
+deals on slow devices).
 
 ## Known limitations / future ideas
 

--- a/lib/bridge/bridge_ai.dart
+++ b/lib/bridge/bridge_ai.dart
@@ -565,57 +565,61 @@ MonteCarloResult chooseCardMonteCarloDD(
   // knows where it is, so the lead is rarely punished and often shows a
   // small spurious edge that a real (non-clairvoyant) declarer wouldn't
   // realize. When the equity-best play is a *lead* of a K or Q with no
-  // effective touching honor and a lower card available, lead low from
-  // the same suit instead, unless the honor lead is decisively better:
-  // by more than the margin AND by a statistically significant paired
-  // difference across sampled deals (genuine coups — cashing before a
-  // ruff, unblocks — clear that bar). All other decisions remain pure
-  // equity: a broad prefer-the-heuristic rule measured -0.86 IMPs/board,
-  // and deferring to the heuristic's cross-suit lead choice within this
-  // guard still measured -0.32.
+  // effective touching honor and a lower card available, play the
+  // best-scoring candidate that doesn't match that pattern instead,
+  // unless the honor lead is decisively better: by more than the margin
+  // AND by a statistically significant paired difference across sampled
+  // deals (genuine coups — cashing before a ruff, pins, unblocks — clear
+  // that bar). All other decisions remain pure equity: deferring to the
+  // heuristic policy instead measured -0.86 IMPs/board applied broadly
+  // and -0.32 within this guard; falling back along the measured-equity
+  // ranking measured +-0. See PLAY_AI.md.
   final margin = playerIsDeclarerSide ? equityMargin : defenderEquityMargin;
   if (margin > 0 && cardReq.currentTrick.cards.isEmpty) {
-    final bCard = legalPlays[best];
-    if (bCard.rank == Rank.king || bCard.rank == Rank.queen) {
-      final suitCards = sortedCardsInSuit(cardReq.hand, bCard.suit);
-      final hasHigher =
-          suitCards.any((c) => c.rank.index > bCard.rank.index);
-      final hasLower =
-          suitCards.any((c) => c.rank.index < bCard.rank.index);
-      final groups = groupsOfEffectivelyIdenticalCards(
-          suitCards, cardReq.previousTricks);
-      final group = groups.firstWhere((g) => g.contains(bCard));
-      final unsupported = group.length == 1 && !hasHigher;
-      if (unsupported && hasLower) {
-        // Compare against the lowest candidate of the *same* suit: the
-        // suit choice (where sampling genuinely outperforms heuristics)
-        // is kept; only the card within the suit is downgraded.
-        int guideIndex = -1;
-        for (int ci = 0; ci < legalPlays.length; ci++) {
-          final c = legalPlays[ci];
-          if (c.suit == bCard.suit &&
-              (guideIndex < 0 ||
-                  c.rank.index < legalPlays[guideIndex].rank.index)) {
-            guideIndex = ci;
-          }
+    // Matches the artifact pattern: a lead of a K or Q with no effective
+    // touching honor, no higher card, and a lower card available in the
+    // suit.
+    bool isArtifactLead(PlayingCard c) {
+      if (c.rank != Rank.king && c.rank != Rank.queen) return false;
+      final suitCards = sortedCardsInSuit(cardReq.hand, c.suit);
+      if (suitCards.any((x) => x.rank.index > c.rank.index)) return false;
+      if (!suitCards.any((x) => x.rank.index < c.rank.index)) return false;
+      final groups =
+          groupsOfEffectivelyIdenticalCards(suitCards, cardReq.previousTricks);
+      return groups.firstWhere((g) => g.contains(c)).length == 1;
+    }
+
+    if (isArtifactLead(legalPlays[best])) {
+      // Fall back to the best-scoring candidate that is NOT itself an
+      // artifact lead; the honor keeps the lead only if it beats that
+      // candidate decisively.
+      int fallback = -1;
+      for (int ci = 0; ci < legalPlays.length; ci++) {
+        if (ci == best || isArtifactLead(legalPlays[ci])) continue;
+        if (fallback < 0 ||
+            playEquities[ci] - playEquities[fallback] > 1e-9 ||
+            ((playEquities[ci] - playEquities[fallback]).abs() <= 1e-9 &&
+                legalPlays[ci].rank.index <
+                    legalPlays[fallback].rank.index)) {
+          fallback = ci;
         }
-        if (guideIndex >= 0 && guideIndex != best) {
-          final n = perRoundEquities.length;
-          final meanDiff =
-              (playEquities[best] - playEquities[guideIndex]) / numRounds;
-          bool decisive = meanDiff > margin;
-          if (decisive && n >= 2) {
-            double sumSq = 0;
-            for (final round in perRoundEquities) {
-              final d = round[best] - round[guideIndex] - meanDiff;
-              sumSq += d * d;
-            }
-            final stderr = sqrt(sumSq / (n - 1) / n);
-            decisive = meanDiff > 2 * stderr;
+      }
+      if (fallback >= 0) {
+        final n = perRoundEquities.length;
+        final meanDiff =
+            (playEquities[best] - playEquities[fallback]) / numRounds;
+        bool decisive = meanDiff > margin;
+        if (decisive && n >= 2) {
+          double sumSq = 0;
+          for (final round in perRoundEquities) {
+            final d = round[best] - round[fallback] - meanDiff;
+            sumSq += d * d;
           }
-          if (!decisive) {
-            best = guideIndex;
-          }
+          final stderr = sqrt(sumSq / (n - 1) / n);
+          decisive = meanDiff > 2 * stderr;
+        }
+        if (!decisive) {
+          best = fallback;
         }
       }
     }

--- a/lib/bridge/bridge_ai.dart
+++ b/lib/bridge/bridge_ai.dart
@@ -319,7 +319,14 @@ class BiddingDealFilter {
       return null;
     }
     final knownSeats = <int>{req.currentPlayerIndex()};
-    if (req.dummyHand != null) knownSeats.add(req.contract.dummy);
+    // On the opening lead the dummy hasn't been revealed, and the deal
+    // sampler doesn't fix its cards, so its auction constraints must
+    // still apply.
+    final dummyRevealed =
+        req.previousTricks.isNotEmpty || req.currentTrick.cards.isNotEmpty;
+    if (req.dummyHand != null && dummyRevealed) {
+      knownSeats.add(req.contract.dummy);
+    }
     if (req.declarerHand != null) knownSeats.add(req.contract.declarer);
 
     final meanings = List<BidMeaning?>.filled(numPlayers, null);
@@ -444,6 +451,8 @@ MonteCarloResult chooseCardMonteCarloDD(
   bool useBiddingInference = true,
   int ddTricksLimit = 8,
   ChooseCardFn? prerollFn,
+  double equityMargin = 5,
+  double defenderEquityMargin = 18,
   int Function()? timeFn,
 }) {
   timeFn ??= () => DateTime.now().millisecondsSinceEpoch;
@@ -471,6 +480,9 @@ MonteCarloResult chooseCardMonteCarloDD(
 
   int numRounds = 0;
   final roundEquities = List.generate(legalPlays.length, (_) => 0.0);
+  // Per-committed-round equities, for the paired significance test in the
+  // guide-preference step below.
+  final perRoundEquities = <List<double>>[];
   outer:
   for (int i = 0; i < maxRounds; i++) {
     final hypoRound = possibleRound(cardReq, distReq, rng, filter: filter);
@@ -520,6 +532,7 @@ MonteCarloResult chooseCardMonteCarloDD(
     for (int ci = 0; ci < legalPlays.length; ci++) {
       playEquities[ci] += roundEquities[ci];
     }
+    perRoundEquities.add(List.of(roundEquities));
     numRounds += 1;
     if (maxTimeMillis != null && timeFn() - startTime >= maxTimeMillis) {
       break;
@@ -545,6 +558,66 @@ MonteCarloResult chooseCardMonteCarloDD(
         (d.abs() <= 1e-9 &&
             legalPlays[ci].rank.index < legalPlays[best].rank.index)) {
       best = ci;
+    }
+  }
+  // Honor-waste guard. Double-dummy evaluation is blind to the main cost
+  // of leading an unsupported high honor: every sampled declarer already
+  // knows where it is, so the lead is rarely punished and often shows a
+  // small spurious edge that a real (non-clairvoyant) declarer wouldn't
+  // realize. When the equity-best play is a *lead* of a K or Q with no
+  // effective touching honor and a lower card available, lead low from
+  // the same suit instead, unless the honor lead is decisively better:
+  // by more than the margin AND by a statistically significant paired
+  // difference across sampled deals (genuine coups — cashing before a
+  // ruff, unblocks — clear that bar). All other decisions remain pure
+  // equity: a broad prefer-the-heuristic rule measured -0.86 IMPs/board,
+  // and deferring to the heuristic's cross-suit lead choice within this
+  // guard still measured -0.32.
+  final margin = playerIsDeclarerSide ? equityMargin : defenderEquityMargin;
+  if (margin > 0 && cardReq.currentTrick.cards.isEmpty) {
+    final bCard = legalPlays[best];
+    if (bCard.rank == Rank.king || bCard.rank == Rank.queen) {
+      final suitCards = sortedCardsInSuit(cardReq.hand, bCard.suit);
+      final hasHigher =
+          suitCards.any((c) => c.rank.index > bCard.rank.index);
+      final hasLower =
+          suitCards.any((c) => c.rank.index < bCard.rank.index);
+      final groups = groupsOfEffectivelyIdenticalCards(
+          suitCards, cardReq.previousTricks);
+      final group = groups.firstWhere((g) => g.contains(bCard));
+      final unsupported = group.length == 1 && !hasHigher;
+      if (unsupported && hasLower) {
+        // Compare against the lowest candidate of the *same* suit: the
+        // suit choice (where sampling genuinely outperforms heuristics)
+        // is kept; only the card within the suit is downgraded.
+        int guideIndex = -1;
+        for (int ci = 0; ci < legalPlays.length; ci++) {
+          final c = legalPlays[ci];
+          if (c.suit == bCard.suit &&
+              (guideIndex < 0 ||
+                  c.rank.index < legalPlays[guideIndex].rank.index)) {
+            guideIndex = ci;
+          }
+        }
+        if (guideIndex >= 0 && guideIndex != best) {
+          final n = perRoundEquities.length;
+          final meanDiff =
+              (playEquities[best] - playEquities[guideIndex]) / numRounds;
+          bool decisive = meanDiff > margin;
+          if (decisive && n >= 2) {
+            double sumSq = 0;
+            for (final round in perRoundEquities) {
+              final d = round[best] - round[guideIndex] - meanDiff;
+              sumSq += d * d;
+            }
+            final stderr = sqrt(sumSq / (n - 1) / n);
+            decisive = meanDiff > 2 * stderr;
+          }
+          if (!decisive) {
+            best = guideIndex;
+          }
+        }
+      }
     }
   }
   return MonteCarloResult(

--- a/lib/bridge/bridge_ai.dart
+++ b/lib/bridge/bridge_ai.dart
@@ -453,6 +453,7 @@ MonteCarloResult chooseCardMonteCarloDD(
   ChooseCardFn? prerollFn,
   double equityMargin = 5,
   double defenderEquityMargin = 18,
+  bool tryFullDepthSolve = true,
   int Function()? timeFn,
 }) {
   timeFn ??= () => DateTime.now().millisecondsSinceEpoch;
@@ -477,12 +478,26 @@ MonteCarloResult chooseCardMonteCarloDD(
   // than blowing the latency budget; the whole sampled deal is then
   // discarded (a per-candidate skip would bias the equities).
   const solveNodeLimit = 3000000;
+  // Full-depth solve attempts get a smaller budget: an abort here is
+  // routine (it just switches this call to preroll mode) and must stay
+  // around ~100ms. Solves that fit are typically 5-50ms.
+  const fullSolveNodeLimit = 1500000;
 
   int numRounds = 0;
   final roundEquities = List.generate(legalPlays.length, (_) => 0.0);
   // Per-committed-round equities, for the paired significance test in the
   // guide-preference step below.
   final perRoundEquities = <List<double>>[];
+  // Prerolling with the heuristic policy before solving injects a little
+  // follow-up competence bias back into the evaluation: a candidate whose
+  // continuation the heuristic misplays gets systematically undervalued,
+  // occasionally inverting decisions. So first try to solve candidate
+  // positions to full depth (cheap in trump-heavy or cash-out positions
+  // thanks to the solver's quick-trick bounds); only if a full solve
+  // aborts on its node budget fall back to preroll-then-solve for the
+  // rest of this call. A deal is always evaluated one way for all
+  // candidates: on a mid-deal abort the deal is discarded and resampled.
+  bool tryFullSolve = tryFullDepthSolve;
   outer:
   for (int i = 0; i < maxRounds; i++) {
     final hypoRound = possibleRound(cardReq, distReq, rng, filter: filter);
@@ -501,10 +516,12 @@ MonteCarloResult chooseCardMonteCarloDD(
       }
       final round = hypoRound.copy();
       round.playCard(legalPlays[ci]);
-      while (!round.isOver() &&
-          13 - round.previousTricks.length > ddTricksLimit) {
-        final req = CardToPlayRequest.fromRoundWithSharedReferences(round);
-        round.playCard(prerollFn(req, rng));
+      if (!tryFullSolve) {
+        while (!round.isOver() &&
+            13 - round.previousTricks.length > ddTricksLimit) {
+          final req = CardToPlayRequest.fromRoundWithSharedReferences(round);
+          round.playCard(prerollFn(req, rng));
+        }
       }
       int declarerTricks;
       if (round.isOver()) {
@@ -517,9 +534,13 @@ MonteCarloResult chooseCardMonteCarloDD(
         for (final c in round.currentTrick.cards) {
           solver.addTrickCard(c);
         }
-        final nsFuture = solver.solveWithNodeLimit(solveNodeLimit);
+        final nsFuture = solver.solveWithNodeLimit(
+            tryFullSolve ? fullSolveNodeLimit : solveNodeLimit);
         if (nsFuture == null) {
-          continue outer; // discard this deal
+          if (tryFullSolve) {
+            tryFullSolve = false;
+          }
+          continue outer; // discard this deal and resample
         }
         final future = 13 - round.previousTricks.length;
         declarerTricks = round.numTricksWonByDeclarer() +

--- a/lib/bridge/play_strategies.dart
+++ b/lib/bridge/play_strategies.dart
@@ -17,6 +17,11 @@
 ///                              heuristic preroll, then double-dummy solve.
 ///     rounds=N, ms=N, bid/nobid  as for mc (bid defaults ON here)
 ///     dd=K                       tricks left at which to solve (default 8)
+///     margin=X, dmargin=X        honor-waste guard margins (points/deal)
+///                                for declarer / defenders; an unsupported
+///                                K/Q lead defers to the heuristic unless
+///                                decisively better (defaults 5 / 18;
+///                                0 disables)
 /// Example: "mc:rollout=heuristic:eps=0.1:rounds=30:rpr=5:ms=2500"
 library;
 
@@ -93,12 +98,16 @@ PlayStrategy makeStrategy(String spec) {
       final ddLimit = int.parse(options["dd"] ?? "8");
       final ms = options.containsKey("ms") ? int.parse(options["ms"]!) : null;
       final useBid = !options.containsKey("nobid");
+      final margin = double.parse(options["margin"] ?? "5");
+      final dmargin = double.parse(options["dmargin"] ?? "18");
       PlayingCard choose(CardToPlayRequest req, Random rng) {
         return chooseCardMonteCarloDD(req, rng,
                 maxRounds: maxRounds,
                 ddTricksLimit: ddLimit,
                 maxTimeMillis: ms,
-                useBiddingInference: useBid)
+                useBiddingInference: useBid,
+                equityMargin: margin,
+                defenderEquityMargin: dmargin)
             .bestCard;
       }
       return PlayStrategy(spec, choose);

--- a/lib/bridge/play_strategies.dart
+++ b/lib/bridge/play_strategies.dart
@@ -100,6 +100,7 @@ PlayStrategy makeStrategy(String spec) {
       final useBid = !options.containsKey("nobid");
       final margin = double.parse(options["margin"] ?? "5");
       final dmargin = double.parse(options["dmargin"] ?? "18");
+      final fullSolve = !options.containsKey("nofull");
       PlayingCard choose(CardToPlayRequest req, Random rng) {
         return chooseCardMonteCarloDD(req, rng,
                 maxRounds: maxRounds,
@@ -107,7 +108,8 @@ PlayStrategy makeStrategy(String spec) {
                 maxTimeMillis: ms,
                 useBiddingInference: useBid,
                 equityMargin: margin,
-                defenderEquityMargin: dmargin)
+                defenderEquityMargin: dmargin,
+                tryFullDepthSolve: fullSolve)
             .bestCard;
       }
       return PlayStrategy(spec, choose);

--- a/scripts/bridge_play_compare.dart
+++ b/scripts/bridge_play_compare.dart
@@ -8,15 +8,20 @@
 /// passed out are skipped (bidding is identical in both rooms, so they
 /// can never produce a difference).
 ///
+/// Boards are played in parallel across isolates. All randomness is
+/// seeded per board, so results are identical regardless of --jobs.
+///
 /// Usage:
 ///   dart run scripts/bridge_play_compare.dart [options] <specA> <specB>
 ///     --deals N     boards to play (default 100)
 ///     --seed N      RNG seed (default 42)
+///     --jobs N      worker isolates (default: cores - 2)
 ///     --quiet       suppress per-board output
 /// Strategy specs are described in lib/bridge/play_strategies.dart.
 library;
 
 import 'dart:io';
+import 'dart:isolate';
 import 'dart:math';
 
 import 'package:cards_with_cats/bridge/bridge.dart';
@@ -34,6 +39,12 @@ class StrategyStats {
       cardsPlayed == 0 ? 0 : elapsedMicros / cardsPlayed / 1000;
 
   double get maxMillisPerPlay => maxMicros / 1000;
+
+  void merge(int cards, int micros, int maxM) {
+    cardsPlayed += cards;
+    elapsedMicros += micros;
+    if (maxM > maxMicros) maxMicros = maxM;
+  }
 }
 
 /// Plays out `round` (bidding already complete). Seats in `teamASeats` use
@@ -83,9 +94,71 @@ bool bidRound(BridgeRound round) {
   return true;
 }
 
-void main(List<String> args) {
+BridgeRound _dealAndBid(int seed, int board) {
+  final dealRng = Random(seed * 1000003 + board);
+  final round = BridgeRound.deal(board % 4, dealRng)
+    ..vulnerability = vulnerabilityForRoundIndex(board);
+  return round;
+}
+
+/// One played board's outcome, sendable across isolates.
+typedef BoardResult = ({
+  int board,
+  int imps,
+  int scoreDiff,
+  String description,
+  int aCards,
+  int aMicros,
+  int aMaxMicros,
+  int bCards,
+  int bMicros,
+  int bMaxMicros,
+});
+
+BoardResult _playBoard(String specA, String specB, int seed, int board) {
+  final a = makeStrategy(specA);
+  final b = makeStrategy(specB);
+  final open = _dealAndBid(seed, board);
+  bidRound(open);
+  final closed = open.copyAndReset();
+  for (final bid in open.bidHistory) {
+    closed.addBid(bid);
+  }
+  final statsA = StrategyStats();
+  final statsB = StrategyStats();
+  // Open room: A holds N-S. Closed room: A holds E-W. Both rooms use the
+  // same RNG seed (common random numbers): identical strategies then play
+  // identically and score zero, and the shared noise cancels in the
+  // difference for similar strategies.
+  playRound(open, a, b, {0, 2}, Random(seed * 7 + board), statsA, statsB);
+  playRound(closed, b, a, {0, 2}, Random(seed * 7 + board), statsB, statsA);
+  final scoreDiff =
+      open.contractScoreForPlayer(0) - closed.contractScoreForPlayer(0);
+  final c = open.contract!;
+  final made = open.tricksTakenByDeclarerOverContract();
+  final madeClosed = closed.tricksTakenByDeclarerOverContract();
+  final description = "${c.bid} by ${"NESW"[c.declarer]}"
+      "${c.doubled != DoubledType.none ? 'X' : ''} "
+      "open ${made >= 0 ? '+' : ''}$made closed "
+      "${madeClosed >= 0 ? '+' : ''}$madeClosed";
+  return (
+    board: board,
+    imps: impsForScoreDifference(scoreDiff),
+    scoreDiff: scoreDiff,
+    description: description,
+    aCards: statsA.cardsPlayed,
+    aMicros: statsA.elapsedMicros,
+    aMaxMicros: statsA.maxMicros,
+    bCards: statsB.cardsPlayed,
+    bMicros: statsB.elapsedMicros,
+    bMaxMicros: statsB.maxMicros,
+  );
+}
+
+void main(List<String> args) async {
   int numDeals = 100;
   int seed = 42;
+  int jobs = max(1, Platform.numberOfProcessors - 2);
   bool quiet = false;
   final specs = <String>[];
   for (int i = 0; i < args.length; i++) {
@@ -94,6 +167,8 @@ void main(List<String> args) {
         numDeals = int.parse(args[++i]);
       case "--seed":
         seed = int.parse(args[++i]);
+      case "--jobs":
+        jobs = max(1, int.parse(args[++i]));
       case "--quiet":
         quiet = true;
       default:
@@ -104,66 +179,67 @@ void main(List<String> args) {
     print("Expected exactly two strategy specs, got $specs");
     exit(1);
   }
-  final a = makeStrategy(specs[0]);
-  final b = makeStrategy(specs[1]);
-  print("A: ${a.name}");
-  print("B: ${b.name}");
+  // Instantiate here to fail fast on bad specs.
+  print("A: ${makeStrategy(specs[0]).name}");
+  print("B: ${makeStrategy(specs[1]).name}");
+
+  final overallWatch = Stopwatch()..start();
+
+  // Bidding is cheap; pre-scan sequentially for the boards the play phase
+  // will use, so results match a sequential run exactly.
+  final playable = <int>[];
+  int passedOut = 0;
+  int biddingFailed = 0;
+  for (int board = 0; playable.length < numDeals; board++) {
+    final round = _dealAndBid(seed, board);
+    if (!bidRound(round)) {
+      biddingFailed++;
+    } else if (round.isPassedOut()) {
+      passedOut++;
+    } else {
+      playable.add(board);
+    }
+  }
+
+  // Fan boards out across worker isolates.
+  final results = List<BoardResult?>.filled(playable.length, null);
+  int nextIndex = 0;
+  Future<void> worker() async {
+    while (true) {
+      final i = nextIndex++;
+      if (i >= playable.length) return;
+      final board = playable[i];
+      results[i] = await Isolate.run(
+          () => _playBoard(specs[0], specs[1], seed, board));
+    }
+  }
+
+  await Future.wait([for (int w = 0; w < jobs; w++) worker()]);
+  overallWatch.stop();
 
   final statsA = StrategyStats();
   final statsB = StrategyStats();
   final impResults = <int>[];
   int totalPointDiff = 0;
-  int passedOut = 0;
-  int biddingFailed = 0;
   int boardsWonByA = 0, boardsWonByB = 0, boardsTied = 0;
-  final overallWatch = Stopwatch()..start();
-
-  for (int board = 0; impResults.length < numDeals; board++) {
-    final dealRng = Random(seed * 1000003 + board);
-    final open = BridgeRound.deal(board % 4, dealRng)
-      ..vulnerability = vulnerabilityForRoundIndex(board);
-    if (!bidRound(open)) {
-      biddingFailed++;
-      continue;
-    }
-    if (open.isPassedOut()) {
-      passedOut++;
-      continue;
-    }
-    final closed = open.copyAndReset();
-    for (final bid in open.bidHistory) {
-      closed.addBid(bid);
-    }
-    // Open room: A holds N-S. Closed room: A holds E-W. Both rooms use the
-    // same RNG seed (common random numbers): identical strategies then play
-    // identically and score zero, and the shared noise cancels in the
-    // difference for similar strategies.
-    playRound(open, a, b, {0, 2}, Random(seed * 7 + board), statsA, statsB);
-    playRound(closed, b, a, {0, 2}, Random(seed * 7 + board), statsB, statsA);
-    final scoreDiff =
-        open.contractScoreForPlayer(0) - closed.contractScoreForPlayer(0);
-    final imps = impsForScoreDifference(scoreDiff);
-    impResults.add(imps);
-    totalPointDiff += scoreDiff;
-    if (imps > 0) {
+  for (final r in results) {
+    if (r == null) continue;
+    impResults.add(r.imps);
+    totalPointDiff += r.scoreDiff;
+    if (r.imps > 0) {
       boardsWonByA++;
-    } else if (imps < 0) {
+    } else if (r.imps < 0) {
       boardsWonByB++;
     } else {
       boardsTied++;
     }
+    statsA.merge(r.aCards, r.aMicros, r.aMaxMicros);
+    statsB.merge(r.bCards, r.bMicros, r.bMaxMicros);
     if (!quiet) {
-      final c = open.contract!;
-      final made = open.tricksTakenByDeclarerOverContract();
-      final madeClosed = closed.tricksTakenByDeclarerOverContract();
-      print("board ${impResults.length}: ${c.bid} by ${"NESW"[c.declarer]}"
-          "${c.doubled != DoubledType.none ? 'X' : ''} "
-          "open ${made >= 0 ? '+' : ''}$made closed "
-          "${madeClosed >= 0 ? '+' : ''}$madeClosed -> "
-          "${imps >= 0 ? '+' : ''}$imps IMPs to A");
+      print("board ${impResults.length}: ${r.description} -> "
+          "${r.imps >= 0 ? '+' : ''}${r.imps} IMPs to A");
     }
   }
-  overallWatch.stop();
 
   final n = impResults.length;
   final mean = impResults.fold(0, (s, x) => s + x) / n;
@@ -184,5 +260,6 @@ void main(List<String> args) {
       "B ${statsB.avgMillisPerPlay.toStringAsFixed(2)} "
       "(max ${statsB.maxMillisPerPlay.toStringAsFixed(0)}, "
       "${statsB.cardsPlayed} plays)");
-  print("elapsed: ${(overallWatch.elapsedMilliseconds / 1000).toStringAsFixed(1)}s");
+  print("elapsed: ${(overallWatch.elapsedMilliseconds / 1000).toStringAsFixed(1)}s "
+      "($jobs jobs)");
 }

--- a/scripts/kx_check.dart
+++ b/scripts/kx_check.dart
@@ -1,0 +1,46 @@
+/// Reproduces a scanned blunder: East (seat 1), defending 3D by North,
+/// leads the king from K2 of spades into dummy's visible AQ9876. Prints
+/// MCDD candidate equities at increasing sample counts.
+library;
+
+import 'dart:math';
+
+import 'package:cards_with_cats/bridge/bridge.dart';
+import 'package:cards_with_cats/bridge/bridge_ai.dart';
+import 'package:cards_with_cats/cards/card.dart';
+import 'package:cards_with_cats/cards/trick.dart';
+
+const c = PlayingCard.cardsFromString;
+
+void main() {
+  final req = CardToPlayRequest(
+    hand: c("KS 2S 7H 6H 5H 3H 9C 7C"),
+    dummyHand: c("AS QS 9S 8S 7S 6S 7D JC"),
+    previousTricks: [
+      Trick(1, c("TS 5S 3S JS"), 0),
+      Trick(0, c("KC 4C 8C AC"), 3),
+      Trick(3, c("3D 2D KD 5D"), 1),
+      Trick(1, c("QH 2H 4H AH"), 0),
+      Trick(0, c("8H KH JH 2C"), 1),
+    ],
+    currentTrick: TrickInProgress(1),
+    bidHistory: [
+      PlayerBid(1, BidAction.fromString("1H")),
+      PlayerBid(2, BidAction.fromString("2S")),
+      PlayerBid(3, BidAction.pass()),
+      PlayerBid(0, BidAction.fromString("3D")),
+      PlayerBid(1, BidAction.pass()),
+      PlayerBid(2, BidAction.pass()),
+      PlayerBid(3, BidAction.pass()),
+    ],
+    vulnerability: Vulnerability.nsOnly,
+  );
+  for (final rounds in [10, 50, 200]) {
+    final result = chooseCardMonteCarloDD(req, Random(48),
+        maxRounds: rounds, ddTricksLimit: 7);
+    final entries = result.cardEquities.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    print("rounds=$rounds best=${result.bestCard}: ${entries.map((e) =>
+        '${e.key}=${e.value.toStringAsFixed(1)}').join(' ')}");
+  }
+}

--- a/scripts/kx_check.dart
+++ b/scripts/kx_check.dart
@@ -1,6 +1,10 @@
-/// Reproduces a scanned blunder: East (seat 1), defending 3D by North,
-/// leads the king from K2 of spades into dummy's visible AQ9876. Prints
-/// MCDD candidate equities at increasing sample counts.
+/// East (seat 1), defending 3D by North, leads the king from K2 of spades
+/// into dummy's visible AQ9876. Under preroll-based evaluation this
+/// scored as a decisive winner (and was rationalized as cashing before
+/// partner ruffs dummy's ace); full-depth solving exposed it as preroll
+/// bias — the exact evaluation ranks the king lead worst. Kept as a
+/// regression case for evaluation quality. Prints MCDD candidate
+/// equities at increasing sample counts.
 library;
 
 import 'dart:math';

--- a/scripts/lead_scan.dart
+++ b/scripts/lead_scan.dart
@@ -1,0 +1,131 @@
+/// Scans AI-played deals for suspicious defensive leads: an unsupported
+/// high honor (K or Q with no touching honor) led from length. Prints each
+/// occurrence with the holding, the visible dummy's cards in the suit, and
+/// what the heuristic policy would have led instead, plus a summary.
+///
+/// Usage: dart run scripts/lead_scan.dart [--deals N] [--seed N] [--dump]
+library;
+
+import 'dart:math';
+
+import 'package:cards_with_cats/bridge/bridge.dart';
+import 'package:cards_with_cats/bridge/bridge_ai.dart';
+import 'package:cards_with_cats/bridge/heuristic_play.dart';
+import 'package:cards_with_cats/bridge/sayc/sayc_bidding.dart';
+import 'package:cards_with_cats/bridge/sayc/selfplay.dart' show isLegalCall;
+import 'package:cards_with_cats/cards/card.dart';
+import 'package:cards_with_cats/cards/rollout.dart';
+
+String suitHolding(List<PlayingCard> hand, Suit s) {
+  final cards = sortedCardsInSuit(hand, s);
+  return cards.isEmpty ? "-" : cards.map((c) => c.rank.asciiChar).join();
+}
+
+void main(List<String> args) {
+  int numDeals = 60;
+  int seed = 7;
+  int mcRounds = 10;
+  double margin = 5;
+  bool dump = false;
+  for (int i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--deals":
+        numDeals = int.parse(args[++i]);
+      case "--seed":
+        seed = int.parse(args[++i]);
+      case "--rounds":
+        mcRounds = int.parse(args[++i]);
+      case "--margin":
+        margin = double.parse(args[++i]);
+      case "--dump":
+        dump = true;
+    }
+  }
+
+  int defenderLeads = 0;
+  int suspiciousLeads = 0;
+  int intoDummyHonor = 0;
+  int heuristicAgreed = 0;
+
+  for (int d = 0; d < numDeals; d++) {
+    final rng = Random(seed * 100003 + d);
+    final round = BridgeRound.deal(d % 4, rng)
+      ..vulnerability = vulnerabilityForRoundIndex(d);
+    bool ok = true;
+    while (round.status == BridgeRoundStatus.bidding) {
+      final seat = round.currentBidder();
+      final history = [for (final b in round.bidHistory) b.action];
+      BidAction call;
+      try {
+        call = selectSaycBid(round.players[seat].hand, history,
+                vulnerability: round.vulnerability)
+            .action;
+      } catch (e) {
+        ok = false;
+        break;
+      }
+      if (!isLegalCall(call, history)) {
+        ok = false;
+        break;
+      }
+      round.addBid(PlayerBid(seat, call));
+    }
+    if (!ok || round.isPassedOut()) continue;
+
+    final contract = round.contract!;
+    while (!round.isOver()) {
+      final req = CardToPlayRequest.fromRound(round);
+      final seat = round.currentPlayerIndex();
+      final isDefender = seat % 2 != contract.declarer % 2;
+      final isLead = round.currentTrick.cards.isEmpty;
+      final card = chooseCardMonteCarloDD(req, Random(seed + d),
+              maxRounds: mcRounds, ddTricksLimit: 7, equityMargin: margin)
+          .bestCard;
+
+      if (isDefender && isLead) {
+        defenderLeads++;
+        final holding = sortedCardsInSuit(req.hand, card.suit);
+        final isKorQ = card.rank == Rank.king || card.rank == Rank.queen;
+        // "Supported" honors use play-aware adjacency: K from KT after the
+        // queen and jack have been played is a solid sequence.
+        final groups = groupsOfEffectivelyIdenticalCards(
+            holding, round.previousTricks);
+        final group = groups.firstWhere((g) => g.contains(card));
+        final hasTouching = group.length >= 2;
+        final hasHigher =
+            holding.any((c) => c.rank.index > card.rank.index);
+        if (isKorQ && holding.length >= 2 && !hasTouching && !hasHigher) {
+          suspiciousLeads++;
+          final dummyCards = req.dummyHand == null
+              ? "?"
+              : suitHolding(req.dummyHand!, card.suit);
+          final dummyHasHonor = req.dummyHand != null &&
+              req.dummyHand!.any((c) =>
+                  c.suit == card.suit &&
+                  c.rank.index > card.rank.index);
+          if (dummyHasHonor) intoDummyHonor++;
+          final hCard = chooseCardHeuristic(req, Random(1));
+          if (hCard == card) heuristicAgreed++;
+          print("deal $d trick ${round.previousTricks.length + 1} "
+              "seat $seat (${contract.bid} by ${"NESW"[contract.declarer]}): "
+              "led $card from ${suitHolding(req.hand, card.suit)} "
+              "dummy=$dummyCards heuristic=$hCard"
+              "${dummyHasHonor ? '  [INTO DUMMY HONOR]' : ''}");
+          if (dump) {
+            print("  hands: ${[
+              for (final p in round.players)
+                PlayingCard.stringFromCards(p.hand)
+            ]}");
+            print("  auction: ${round.bidHistory.map((b) => b.action).join(' ')}");
+            print("  tricks so far: ${round.previousTricks.map((t) => PlayingCard.stringFromCards(t.cards)).join(' | ')}");
+          }
+        }
+      }
+      round.playCard(card);
+    }
+  }
+  print("");
+  print("defender leads: $defenderLeads; unsupported K/Q honor leads: "
+      "$suspiciousLeads ($intoDummyHonor into a higher dummy honor; "
+      "heuristic agreed with $heuristicAgreed)");
+}

--- a/scripts/weird_duck_check.dart
+++ b/scripts/weird_duck_check.dart
@@ -75,56 +75,67 @@ void main() {
   evaluateBothWays("trick1 declarer", reqA);
 
   // Dummy (seat 0) second to trick 2: W won the ace and continues the 3.
-  // Dummy holds K6 of diamonds; East's JD is still out.
-  final reqB = CardToPlayRequest(
-    hand: c("AS 8S 5S 2S JH 7H KD 6D QC 5C 4C 3C"),
-    declarerHand: c("KS QS JS TS 7S 6S AH QH TH TD AC KC"),
-    previousTricks: [
-      Trick(3, c("AD 4D 2D QD"), 3),
-    ],
-    currentTrick: TrickInProgress(3, c("3D")),
-    bidHistory: bids,
-    vulnerability: Vulnerability.neither,
-  );
-  evaluateBothWays("trick2 dummy  ", reqB);
+  // Dummy holds K6 of diamonds; East's JD is still out. Two variants:
+  // - With QC in dummy, ducking is a legitimate alternative line: if West
+  //   holds the jack, declarer's ten scores en passant and the K plus QC
+  //   later provide two heart pitches, replacing the heart finesse with a
+  //   diamond finesse (near-tied equities, resolving toward the K).
+  // - With the QC weakened to 6C (variant due to Brian), only one pitch
+  //   exists, the heart finesse is needed in both lines, and ducking is
+  //   strictly wrong: it never gains and loses a trick whenever East has
+  //   the jack. Full-depth evaluation prefers the K decisively; preroll
+  //   evaluation still ducks — a sharp regression case for preroll bias.
+  for (final (clubs, label) in [("QC", "QC variant"), ("6C", "6C variant")]) {
+    final reqB = CardToPlayRequest(
+      hand: c("AS 8S 5S 2S JH 7H KD 6D $clubs 5C 4C 3C"),
+      declarerHand: c("KS QS JS TS 7S 6S AH QH TH TD AC KC"),
+      previousTricks: [
+        Trick(3, c("AD 4D 2D QD"), 3),
+      ],
+      currentTrick: TrickInProgress(3, c("3D")),
+      bidHistory: bids,
+      vulnerability: Vulnerability.neither,
+    );
+    evaluateBothWays("trick2 dummy $label", reqB);
 
-  // Per-layout audit of the trick-2 duck: sample deals consistent with
-  // the position and compare double-dummy declarer tricks after ducking
-  // (6D) vs winning (KD). Negative diffs mean ducking costs tricks.
-  final distReq = makeCardDistributionRequest(reqB);
-  final filter = BiddingDealFilter.fromRequest(reqB);
-  final rng = Random(9);
-  final diffCounts = <int, int>{};
-  // Split by which defender holds the outstanding JD: with East (seat 1)
-  // ducking should tend to cost a trick, with West (seat 3) it tends to
-  // gain one (declarer's T scores en passant and the K stays master).
-  final diffCountsByJd = {1: <int, int>{}, 3: <int, int>{}};
-  for (int i = 0; i < 40; i++) {
-    final hypo = possibleRound(reqB, distReq, rng, filter: filter);
-    if (hypo == null) break;
-    final jd = c("JD")[0];
-    final jdHolder = hypo.players[1].hand.contains(jd) ? 1 : 3;
-    final tricks = <int>[];
-    for (final play in c("6D KD")) {
-      final round = hypo.copy();
-      round.playCard(play);
-      final hands = [for (final p in round.players) p.hand];
-      final solver = DDSolver.fromHands(
-          hands, Suit.spades, round.currentTrick.leader);
-      for (final tc in round.currentTrick.cards) {
-        solver.addTrickCard(tc);
+    // Per-layout audit: sample deals consistent with the position and
+    // compare double-dummy declarer tricks after ducking (6D) vs winning
+    // (KD). Negative diffs mean ducking costs tricks. Split by which
+    // defender holds the outstanding JD: with East, ducking tends to
+    // cost a trick; with West, it can only help.
+    final distReq = makeCardDistributionRequest(reqB);
+    final filter = BiddingDealFilter.fromRequest(reqB);
+    final rng = Random(9);
+    final diffCounts = <int, int>{};
+    final diffCountsByJd = {1: <int, int>{}, 3: <int, int>{}};
+    for (int i = 0; i < 40; i++) {
+      final hypo = possibleRound(reqB, distReq, rng, filter: filter);
+      if (hypo == null) break;
+      final jd = c("JD")[0];
+      final jdHolder = hypo.players[1].hand.contains(jd) ? 1 : 3;
+      final tricks = <int>[];
+      for (final play in c("6D KD")) {
+        final round = hypo.copy();
+        round.playCard(play);
+        final hands = [for (final p in round.players) p.hand];
+        final solver = DDSolver.fromHands(
+            hands, Suit.spades, round.currentTrick.leader);
+        for (final tc in round.currentTrick.cards) {
+          solver.addTrickCard(tc);
+        }
+        // Declarer is seat 2 (NS side); the solver counts the
+        // in-progress trick.
+        tricks.add(round.numTricksWonByDeclarer() + solver.solve());
       }
-      // Declarer is seat 2 (NS side); solver counts the in-progress trick.
-      tricks.add(round.numTricksWonByDeclarer() + solver.solve());
+      final diff = tricks[0] - tricks[1]; // duck minus win
+      diffCounts[diff] = (diffCounts[diff] ?? 0) + 1;
+      diffCountsByJd[jdHolder]![diff] =
+          (diffCountsByJd[jdHolder]![diff] ?? 0) + 1;
     }
-    final diff = tricks[0] - tricks[1]; // duck minus win
-    diffCounts[diff] = (diffCounts[diff] ?? 0) + 1;
-    diffCountsByJd[jdHolder]![diff] =
-        (diffCountsByJd[jdHolder]![diff] ?? 0) + 1;
+    String fmt(Map<int, int> m) =>
+        (m.keys.toList()..sort()).map((k) => '$k:${m[k]}').join(' ');
+    print("$label duck-vs-win trick diff distribution: ${fmt(diffCounts)}");
+    print("  when East holds JD: ${fmt(diffCountsByJd[1]!)}");
+    print("  when West holds JD: ${fmt(diffCountsByJd[3]!)}");
   }
-  String fmt(Map<int, int> m) =>
-      (m.keys.toList()..sort()).map((k) => '$k:${m[k]}').join(' ');
-  print("duck-vs-win declarer trick diff distribution: ${fmt(diffCounts)}");
-  print("  when East holds JD: ${fmt(diffCountsByJd[1]!)}");
-  print("  when West holds JD: ${fmt(diffCountsByJd[3]!)}");
 }

--- a/scripts/weird_duck_check.dart
+++ b/scripts/weird_duck_check.dart
@@ -95,9 +95,15 @@ void main() {
   final filter = BiddingDealFilter.fromRequest(reqB);
   final rng = Random(9);
   final diffCounts = <int, int>{};
+  // Split by which defender holds the outstanding JD: with East (seat 1)
+  // ducking should tend to cost a trick, with West (seat 3) it tends to
+  // gain one (declarer's T scores en passant and the K stays master).
+  final diffCountsByJd = {1: <int, int>{}, 3: <int, int>{}};
   for (int i = 0; i < 40; i++) {
     final hypo = possibleRound(reqB, distReq, rng, filter: filter);
     if (hypo == null) break;
+    final jd = c("JD")[0];
+    final jdHolder = hypo.players[1].hand.contains(jd) ? 1 : 3;
     final tricks = <int>[];
     for (final play in c("6D KD")) {
       final round = hypo.copy();
@@ -113,7 +119,12 @@ void main() {
     }
     final diff = tricks[0] - tricks[1]; // duck minus win
     diffCounts[diff] = (diffCounts[diff] ?? 0) + 1;
+    diffCountsByJd[jdHolder]![diff] =
+        (diffCountsByJd[jdHolder]![diff] ?? 0) + 1;
   }
-  print("duck-vs-win declarer trick diff distribution: "
-      "${(diffCounts.keys.toList()..sort()).map((k) => '$k:${diffCounts[k]}').join(' ')}");
+  String fmt(Map<int, int> m) =>
+      (m.keys.toList()..sort()).map((k) => '$k:${m[k]}').join(' ');
+  print("duck-vs-win declarer trick diff distribution: ${fmt(diffCounts)}");
+  print("  when East holds JD: ${fmt(diffCountsByJd[1]!)}");
+  print("  when West holds JD: ${fmt(diffCountsByJd[3]!)}");
 }

--- a/scripts/weird_duck_check.dart
+++ b/scripts/weird_duck_check.dart
@@ -3,7 +3,16 @@
 /// Trick 1: W leads AD, dummy low, E low — declarer drops the QD from QT.
 /// Trick 2: W continues a low diamond — dummy ducks with K6, losing to
 /// East's jack.
-/// Prints MCDD candidate equities at both decision points.
+///
+/// Both decision points are evaluated two ways:
+///   preroll:   the pre-fix evaluation — play forward with the heuristic
+///              policy until 7 tricks remain, then solve exactly. Its
+///              preference for the trick-2 duck (~+30 points) was preroll
+///              bias: the heuristic misplayed the win-the-K continuations.
+///   fullsolve: solve each candidate position exactly from the decision
+///              point (the shipped default).
+/// A per-layout audit then shows ground truth: for sampled layouts, the
+/// exact declarer-trick difference of ducking vs winning.
 library;
 
 import 'dart:math';
@@ -39,6 +48,19 @@ void printEquities(String label, MonteCarloResult result) {
       '${e.key}=${e.value.toStringAsFixed(1)}').join(' ')}");
 }
 
+void evaluateBothWays(String label, CardToPlayRequest req) {
+  for (final rounds in [20, 100]) {
+    printEquities(
+        "$label preroll   rounds=$rounds",
+        chooseCardMonteCarloDD(req, Random(3),
+            maxRounds: rounds, ddTricksLimit: 7, tryFullDepthSolve: false));
+    printEquities(
+        "$label fullsolve rounds=$rounds",
+        chooseCardMonteCarloDD(req, Random(3),
+            maxRounds: rounds, ddTricksLimit: 7));
+  }
+}
+
 void main() {
   // Declarer (seat 2) fourth to trick 1: AD led, dummy played the 4, E
   // the 2. Declarer holds QT of diamonds.
@@ -50,11 +72,7 @@ void main() {
     bidHistory: bids,
     vulnerability: Vulnerability.neither,
   );
-  for (final rounds in [20, 100]) {
-    printEquities("trick1 declarer rounds=$rounds",
-        chooseCardMonteCarloDD(reqA, Random(3), maxRounds: rounds,
-            ddTricksLimit: 7));
-  }
+  evaluateBothWays("trick1 declarer", reqA);
 
   // Dummy (seat 0) second to trick 2: W won the ace and continues the 3.
   // Dummy holds K6 of diamonds; East's JD is still out.
@@ -68,15 +86,11 @@ void main() {
     bidHistory: bids,
     vulnerability: Vulnerability.neither,
   );
-  for (final rounds in [20, 100]) {
-    printEquities("trick2 dummy   rounds=$rounds",
-        chooseCardMonteCarloDD(reqB, Random(3), maxRounds: rounds,
-            ddTricksLimit: 7));
-  }
+  evaluateBothWays("trick2 dummy  ", reqB);
 
   // Per-layout audit of the trick-2 duck: sample deals consistent with
   // the position and compare double-dummy declarer tricks after ducking
-  // (6D) vs winning (KD).
+  // (6D) vs winning (KD). Negative diffs mean ducking costs tricks.
   final distReq = makeCardDistributionRequest(reqB);
   final filter = BiddingDealFilter.fromRequest(reqB);
   final rng = Random(9);

--- a/scripts/weird_duck_check.dart
+++ b/scripts/weird_duck_check.dart
@@ -1,0 +1,105 @@
+/// Reproduces two reported oddities in the same 4S deal:
+///   declarer: KQJT76 AQT QT AK   dummy: A852 J7 K64 Q543
+/// Trick 1: W leads AD, dummy low, E low — declarer drops the QD from QT.
+/// Trick 2: W continues a low diamond — dummy ducks with K6, losing to
+/// East's jack.
+/// Prints MCDD candidate equities at both decision points.
+library;
+
+import 'dart:math';
+
+import 'package:cards_with_cats/bridge/bridge.dart';
+import 'package:cards_with_cats/bridge/bridge_ai.dart';
+import 'package:cards_with_cats/bridge/dd_solver.dart';
+import 'package:cards_with_cats/cards/card.dart';
+import 'package:cards_with_cats/cards/rollout.dart';
+import 'package:cards_with_cats/cards/trick.dart';
+
+const c = PlayingCard.cardsFromString;
+
+final bids = [
+  PlayerBid(2, BidAction.fromString("2C")),
+  PlayerBid(3, BidAction.pass()),
+  PlayerBid(0, BidAction.fromString("2D")),
+  PlayerBid(1, BidAction.pass()),
+  PlayerBid(2, BidAction.fromString("2S")),
+  PlayerBid(3, BidAction.pass()),
+  PlayerBid(0, BidAction.fromString("3S")),
+  PlayerBid(1, BidAction.pass()),
+  PlayerBid(2, BidAction.fromString("4S")),
+  PlayerBid(3, BidAction.pass()),
+  PlayerBid(0, BidAction.pass()),
+  PlayerBid(1, BidAction.pass()),
+];
+
+void printEquities(String label, MonteCarloResult result) {
+  final entries = result.cardEquities.entries.toList()
+    ..sort((a, b) => b.value.compareTo(a.value));
+  print("$label best=${result.bestCard}: ${entries.map((e) =>
+      '${e.key}=${e.value.toStringAsFixed(1)}').join(' ')}");
+}
+
+void main() {
+  // Declarer (seat 2) fourth to trick 1: AD led, dummy played the 4, E
+  // the 2. Declarer holds QT of diamonds.
+  final reqA = CardToPlayRequest(
+    hand: c("KS QS JS TS 7S 6S AH QH TH QD TD AC KC"),
+    dummyHand: c("AS 8S 5S 2S JH 7H KD 6D QC 5C 4C 3C"),
+    previousTricks: [],
+    currentTrick: TrickInProgress(3, c("AD 4D 2D")),
+    bidHistory: bids,
+    vulnerability: Vulnerability.neither,
+  );
+  for (final rounds in [20, 100]) {
+    printEquities("trick1 declarer rounds=$rounds",
+        chooseCardMonteCarloDD(reqA, Random(3), maxRounds: rounds,
+            ddTricksLimit: 7));
+  }
+
+  // Dummy (seat 0) second to trick 2: W won the ace and continues the 3.
+  // Dummy holds K6 of diamonds; East's JD is still out.
+  final reqB = CardToPlayRequest(
+    hand: c("AS 8S 5S 2S JH 7H KD 6D QC 5C 4C 3C"),
+    declarerHand: c("KS QS JS TS 7S 6S AH QH TH TD AC KC"),
+    previousTricks: [
+      Trick(3, c("AD 4D 2D QD"), 3),
+    ],
+    currentTrick: TrickInProgress(3, c("3D")),
+    bidHistory: bids,
+    vulnerability: Vulnerability.neither,
+  );
+  for (final rounds in [20, 100]) {
+    printEquities("trick2 dummy   rounds=$rounds",
+        chooseCardMonteCarloDD(reqB, Random(3), maxRounds: rounds,
+            ddTricksLimit: 7));
+  }
+
+  // Per-layout audit of the trick-2 duck: sample deals consistent with
+  // the position and compare double-dummy declarer tricks after ducking
+  // (6D) vs winning (KD).
+  final distReq = makeCardDistributionRequest(reqB);
+  final filter = BiddingDealFilter.fromRequest(reqB);
+  final rng = Random(9);
+  final diffCounts = <int, int>{};
+  for (int i = 0; i < 40; i++) {
+    final hypo = possibleRound(reqB, distReq, rng, filter: filter);
+    if (hypo == null) break;
+    final tricks = <int>[];
+    for (final play in c("6D KD")) {
+      final round = hypo.copy();
+      round.playCard(play);
+      final hands = [for (final p in round.players) p.hand];
+      final solver = DDSolver.fromHands(
+          hands, Suit.spades, round.currentTrick.leader);
+      for (final tc in round.currentTrick.cards) {
+        solver.addTrickCard(tc);
+      }
+      // Declarer is seat 2 (NS side); solver counts the in-progress trick.
+      tricks.add(round.numTricksWonByDeclarer() + solver.solve());
+    }
+    final diff = tricks[0] - tricks[1]; // duck minus win
+    diffCounts[diff] = (diffCounts[diff] ?? 0) + 1;
+  }
+  print("duck-vs-win declarer trick diff distribution: "
+      "${(diffCounts.keys.toList()..sort()).map((k) => '$k:${diffCounts[k]}').join(' ')}");
+}


### PR DESCRIPTION
This gains about 1 IMP/hand compared to the previous strategy of MC rollouts with heuristic play down to 7 cards before double-dummy solving. Includes a script to reproduce a decision that the heuristic gets wrong and the full solve gets right. Performance is slower but still acceptable.