### PR TITLE
Improve bridge honor play

### DIFF
--- a/lib/bridge/PLAY_AI.md
+++ b/lib/bridge/PLAY_AI.md
@@ -191,6 +191,16 @@ Lesson: suppress only the exact artifact pattern and fall back along the
 measured-equity ranking, not to conventional play; every deferral to the
 heuristic's judgment costs measurable equity.
 
+Re-measured after full-depth solving landed: the guard remains
+worthwhile — +0.31 +/- 0.18 IMPs/board vs guard-off (200 boards; free
+to mildly positive), while still halving flagged unsupported-honor
+leads (25 -> 12 at 50 sampled deals; into-dummy-honor leads 8 -> 2),
+because exact evaluation still leaves plenty of genuine ties. Two
+naturalness refinements: a K/Q that has become the *master* is exempt
+(cashing it is never the artifact), and lead candidates from groups of
+touching honors are represented by the top card (lead A from AKQ, not
+the double-dummy-equivalent Q).
+
 ## Full-depth solving (preroll bias)
 
 A reported oddity (dummy ducking with a master K-x behind it, in a

--- a/lib/bridge/bridge_ai.dart
+++ b/lib/bridge/bridge_ai.dart
@@ -89,10 +89,18 @@ List<PlayingCard> cardsToConsiderPlaying(CardToPlayRequest req, Random rng) {
   // Cards that are interchangeable for trick-taking (e.g. the queen and
   // jack of a suit when holding both) need only one representative; play
   // the cheapest. This shrinks the branching factor and stops equity noise
-  // from picking a wastefully high equal.
+  // from picking a wastefully high equal. Exception: when *leading* from
+  // a group of touching honors, represent it by its top card — leading Q
+  // from AKQ is equivalent double-dummy but conventionally backwards.
+  final leading = req.currentTrick.cards.isEmpty;
   final groups = groupsOfEffectivelyIdenticalCards(
       req.legalPlays(), req.previousTricks);
-  return [for (final g in groups) g.last];
+  return [
+    for (final g in groups)
+      leading && g.length >= 2 && g.first.rank.index >= Rank.ten.index
+          ? g.first
+          : g.last
+  ];
 }
 
 PlayingCard chooseCardRandom(final CardToPlayRequest req, Random rng) {
@@ -605,6 +613,26 @@ MonteCarloResult chooseCardMonteCarloDD(
       final suitCards = sortedCardsInSuit(cardReq.hand, c.suit);
       if (suitCards.any((x) => x.rank.index > c.rank.index)) return false;
       if (!suitCards.any((x) => x.rank.index < c.rank.index)) return false;
+      // A master can't be captured, so cashing it is never the artifact
+      // (e.g. continuing a now-master king after the ace and queen have
+      // been played). Higher cards seen in play or in a visible hand of
+      // our own side don't threaten it.
+      final seen = <PlayingCard>{};
+      for (final t in cardReq.previousTricks) {
+        seen.addAll(t.cards);
+      }
+      final partnerVisible =
+          playerIsDeclarerSide ? (cardReq.dummyHand ?? cardReq.declarerHand) : null;
+      bool isMaster = true;
+      for (var r = c.rank; r != Rank.ace && isMaster;) {
+        r = r.nextHigherRank();
+        final higher = PlayingCard(r, c.suit);
+        if (!seen.contains(higher) &&
+            !(partnerVisible?.contains(higher) ?? false)) {
+          isMaster = false;
+        }
+      }
+      if (isMaster) return false;
       final groups =
           groupsOfEffectivelyIdenticalCards(suitCards, cardReq.previousTricks);
       return groups.firstWhere((g) => g.contains(c)).length == 1;

--- a/scripts/lead_scan.dart
+++ b/scripts/lead_scan.dart
@@ -79,7 +79,10 @@ void main(List<String> args) {
       final isDefender = seat % 2 != contract.declarer % 2;
       final isLead = round.currentTrick.cards.isEmpty;
       final card = chooseCardMonteCarloDD(req, Random(seed + d),
-              maxRounds: mcRounds, ddTricksLimit: 7, equityMargin: margin)
+              maxRounds: mcRounds,
+              ddTricksLimit: 7,
+              equityMargin: margin,
+              defenderEquityMargin: margin == 0 ? 0 : 18)
           .bestCard;
 
       if (isDefender && isLead) {

--- a/scripts/weird_duck_check.dart
+++ b/scripts/weird_duck_check.dart
@@ -80,11 +80,11 @@ void main() {
   //   holds the jack, declarer's ten scores en passant and the K plus QC
   //   later provide two heart pitches, replacing the heart finesse with a
   //   diamond finesse (near-tied equities, resolving toward the K).
-  // - With the QC weakened to 6C (variant due to Brian), only one pitch
-  //   exists, the heart finesse is needed in both lines, and ducking is
-  //   strictly wrong: it never gains and loses a trick whenever East has
-  //   the jack. Full-depth evaluation prefers the K decisively; preroll
-  //   evaluation still ducks — a sharp regression case for preroll bias.
+  // - With the QC weakened to 6C, only one pitch exists, the heart finesse is
+  //   needed in both lines, and ducking is strictly wrong: it never gains,
+  //   and loses a trick whenever East has the jack. Full-depth evaluation
+  //   prefers the K decisively; preroll evaluation still ducks — a sharp
+  //   regression case for preroll bias.
   for (final (clubs, label) in [("QC", "QC variant"), ("6C", "6C variant")]) {
     final reqB = CardToPlayRequest(
       hand: c("AS 8S 5S 2S JH 7H KD 6D $clubs 5C 4C 3C"),

--- a/test/bridge/bridge_ai_test.dart
+++ b/test/bridge/bridge_ai_test.dart
@@ -41,6 +41,42 @@ void main() {
     expect(result.bestCard, c("QS")[0]);
   });
 
+  test("candidate leads use the top of touching honors", () {
+    final bids = [
+      PlayerBid(0, BidAction.noTrump(3)),
+      PlayerBid(1, BidAction.pass()),
+      PlayerBid(2, BidAction.pass()),
+      PlayerBid(3, BidAction.pass()),
+    ];
+    final hand = c("AS KS QS 2S 5H 4H 3H 2H 4D 3D 2D 3C 2C");
+    final rng = Random(17);
+
+    // Leading: the AKQ group is represented by the ace (conventional
+    // top-of-sequence lead), low groups by their cheapest card.
+    final leadReq = CardToPlayRequest(
+      hand: hand,
+      previousTricks: [],
+      currentTrick: TrickInProgress(1),
+      bidHistory: bids,
+      vulnerability: Vulnerability.neither,
+    );
+    final leads = cardsToConsiderPlaying(leadReq, rng).toSet();
+    expect(leads, containsAll(c("AS 2S 2H 2D 2C")));
+    expect(leads, isNot(contains(c("QS")[0])));
+    expect(leads, isNot(contains(c("KS")[0])));
+
+    // Following to a spade lead: lowest of equals as before.
+    final followReq = CardToPlayRequest(
+      hand: hand,
+      previousTricks: [],
+      currentTrick: TrickInProgress(0, c("5S")),
+      bidHistory: bids,
+      vulnerability: Vulnerability.neither,
+    );
+    final follows = cardsToConsiderPlaying(followReq, rng).toSet();
+    expect(follows, c("QS 2S").toSet());
+  });
+
   test("mcdd finds the finesse", () {
     final req = CardToPlayRequest(
       declarerHand: c("3S 2S AH KH QH JH TH AD KD QD AC KC QC"),


### PR DESCRIPTION
Lead highest connected honor (e.g. K from KQx), don't treat cashing K or Q as suspicious when it's the highest outstanding card.