### PR TITLE
Support dds double-dummy solver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 /android/app/.cxx
+native/

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ app.*.map.json
 /android/app/release
 /android/app/.cxx
 native/
+android/app/src/main/jniLibs/

--- a/lib/bridge/PLAY_AI.md
+++ b/lib/bridge/PLAY_AI.md
@@ -35,8 +35,15 @@ Bitmask hands; zero-window alpha-beta with a binary search over the trick
 target; transposition table at trick boundaries storing (lower, upper)
 bound pairs plus the best move for ordering; equivalence-class move
 generation; an exact last-seat reduction (win as cheaply as possible, duck
-with the lowest, or unblock with the highest). Validated by fuzzing
-against an unpruned reference solver (`DDReferenceSolver`).
+with the lowest, or unblock with the highest). Validated two ways: by
+fuzzing against an unpruned reference solver (`DDReferenceSolver`), and
+externally against the established dds-bridge/dds C++ solver
+(`scripts/dds_compare/`) — 5000+ random positions at 2-12 tricks with
+mixed trumps, leaders, and partial tricks, zero disagreements. DDS
+remains far faster at depth (~1000x at 11-12 tricks; it has two decades
+of optimization including partition search), which is why MCDD's
+full-depth solves carry a node budget rather than assuming full deals
+are cheap.
 
 Timing on random deals: ~1ms at 6 tricks remaining, ~12ms at 8, ~34ms at
 9, ~1-7s at 10-12 (desktop M4, JIT). Three throughput features matter in

--- a/lib/bridge/PLAY_AI.md
+++ b/lib/bridge/PLAY_AI.md
@@ -270,11 +270,17 @@ call is synchronous). All slots busy → solve returns null → pure-Dart
 fallback. Binding validated against DDSolver on 5000+ random positions
 (zero mismatches); `dds_isolate_probe.dart` covers the isolate cases.
 
-Not yet done for production/mobile: per-platform library builds and
-bundling (Android CMake via Gradle, iOS static lib/xcframework, macOS
-bundle + entitlements), loading from the app bundle instead of the
-DDS_LIB environment variable, and capping DDS memory on low-RAM devices
-(SetResources instead of SetMaxThreads in the shim).
+Platform integration: `build_libdds.sh` (host or `android`) produces
+the libraries locally — outputs are gitignored, so run it before
+building the app with dds support. macOS embeds `native/libdds.dylib`
+into Contents/Frameworks via an "Embed libdds" Runner build phase
+(copy + codesign, skipped when the dylib is absent so builds never
+break); Android cross-builds `libdds.so` for arm64-v8a, armeabi-v7a,
+and x86_64 into jniLibs, where the loader finds it by name. The shim
+caps DDS memory on Android (SetResources) since DDS otherwise sizes
+transposition tables from free RAM. DDS_LIB remains a development
+override; iOS (which requires static linking and
+DynamicLibrary.process()) is not yet done.
 
 ## Known limitations / future ideas
 

--- a/lib/bridge/PLAY_AI.md
+++ b/lib/bridge/PLAY_AI.md
@@ -241,6 +241,41 @@ With full-depth solving, the engine's direct margin over an MC with
 maxtricks rollouts (the strongest pre-project baseline) is
 **+2.07 +/- 0.27 IMPs/board** (300 boards, seed 21, 156-48-96).
 
+## Native dds backend (FFI)
+
+`lib/bridge/dds_ffi.dart` binds SolveBoard from a libdds dynamic library
+(dds-bridge/dds v2.9.0 built by `scripts/dds_compare/build_libdds.sh`).
+Opt in by setting `DDS_LIB` to the library path; when unset or
+unloadable, everything falls back to the pure-Dart `DDSolver`, so
+platforms without the library are unaffected. With the backend active,
+MCDD solves every candidate position to full depth — no preroll, no
+node budget.
+
+Measured at mcdd:rounds=10:dd=7 over 100 boards, dds vs pure Dart:
+**+1.46 +/- 0.40 IMPs/board** (48-17-35) — the pure side pays the
+preroll-bias tax whenever its node budget forces a fallback, the dds
+side never does — at ~26ms vs ~767ms average per play under a fully
+parallel harness (~10ms vs ~130ms uncontended). The speed headroom is
+the point for mobile: full evaluation quality on slow devices, and an
+order of magnitude less CPU per play.
+
+The delicate part was multi-isolate safety, handled by a shim compiled
+into our libdds build (`dds_shim.cpp`): DDS thread memory must be
+initialized exactly once per process (a second SetMaxThreads corrupts
+in-flight state, and GetDDSInfo crashes if called before init), and
+concurrent solves need exclusive thread indices — a round-robin
+dispenser is insufficient because solves finish out of order, so every
+solve brackets acquire/release of a slot (safe against leaks: the FFI
+call is synchronous). All slots busy → solve returns null → pure-Dart
+fallback. Binding validated against DDSolver on 5000+ random positions
+(zero mismatches); `dds_isolate_probe.dart` covers the isolate cases.
+
+Not yet done for production/mobile: per-platform library builds and
+bundling (Android CMake via Gradle, iOS static lib/xcframework, macOS
+bundle + entitlements), loading from the app bundle instead of the
+DDS_LIB environment variable, and capping DDS memory on low-RAM devices
+(SetResources instead of SetMaxThreads in the shim).
+
 ## Known limitations / future ideas
 
 - Double-dummy defenders "see" declarer's cards within each sampled deal

--- a/lib/bridge/bridge_ai.dart
+++ b/lib/bridge/bridge_ai.dart
@@ -7,6 +7,7 @@ import "../cards/trick.dart";
 import "bridge.dart";
 import "bridge.dart" as bridge;
 import "dd_solver.dart";
+import "dds_ffi.dart";
 import "heuristic_play.dart";
 import "sayc/sayc_bidding.dart" show BidMeaning, HandAnalysis, explainSaycAuction;
 
@@ -462,6 +463,7 @@ MonteCarloResult chooseCardMonteCarloDD(
   double equityMargin = 5,
   double defenderEquityMargin = 18,
   bool tryFullDepthSolve = true,
+  bool useDdsBackend = true,
   int Function()? timeFn,
 }) {
   timeFn ??= () => DateTime.now().millisecondsSinceEpoch;
@@ -506,6 +508,10 @@ MonteCarloResult chooseCardMonteCarloDD(
   // rest of this call. A deal is always evaluated one way for all
   // candidates: on a mid-deal abort the deal is discarded and resampled.
   bool tryFullSolve = tryFullDepthSolve;
+  // When the native dds library is available (see dds_ffi.dart), every
+  // candidate position solves to full depth in microseconds: no preroll,
+  // no node budget. Falls back to the pure-Dart solver otherwise.
+  final dds = useDdsBackend ? DdsBackend.instance : null;
   outer:
   for (int i = 0; i < maxRounds; i++) {
     final hypoRound = possibleRound(cardReq, distReq, rng, filter: filter);
@@ -524,7 +530,7 @@ MonteCarloResult chooseCardMonteCarloDD(
       }
       final round = hypoRound.copy();
       round.playCard(legalPlays[ci]);
-      if (!tryFullSolve) {
+      if (!tryFullSolve && dds == null) {
         while (!round.isOver() &&
             13 - round.previousTricks.length > ddTricksLimit) {
           final req = CardToPlayRequest.fromRoundWithSharedReferences(round);
@@ -536,14 +542,18 @@ MonteCarloResult chooseCardMonteCarloDD(
         declarerTricks = round.numTricksWonByDeclarer();
       } else {
         final hands = [for (final p in round.players) p.hand];
-        final solver = DDSolver.fromHands(
-            hands, contract.bid.trump, round.currentTrick.leader,
-            sharedTable: sharedTable);
-        for (final c in round.currentTrick.cards) {
-          solver.addTrickCard(c);
+        int? nsFuture = dds?.solve(hands, contract.bid.trump,
+            round.currentTrick.leader, round.currentTrick.cards);
+        if (nsFuture == null) {
+          final solver = DDSolver.fromHands(
+              hands, contract.bid.trump, round.currentTrick.leader,
+              sharedTable: sharedTable);
+          for (final c in round.currentTrick.cards) {
+            solver.addTrickCard(c);
+          }
+          nsFuture = solver.solveWithNodeLimit(
+              tryFullSolve ? fullSolveNodeLimit : solveNodeLimit);
         }
-        final nsFuture = solver.solveWithNodeLimit(
-            tryFullSolve ? fullSolveNodeLimit : solveNodeLimit);
         if (nsFuture == null) {
           if (tryFullSolve) {
             tryFullSolve = false;

--- a/lib/bridge/dd_solver.dart
+++ b/lib/bridge/dd_solver.dart
@@ -31,6 +31,10 @@ class DDSolver {
 
   int _nodesRemaining = 1 << 60;
 
+  /// Nodes visited by [solve] since construction (not meaningful after
+  /// [solveWithNodeLimit], which repurposes the counter as a budget).
+  int get nodesSearched => (1 << 60) - _nodesRemaining;
+
   DDSolver._(this.holdings, this.trump, this.leader, Map<int, int>? shared)
       : _transposition = shared ?? {};
 

--- a/lib/bridge/dds_ffi.dart
+++ b/lib/bridge/dds_ffi.dart
@@ -10,8 +10,11 @@
 /// thread indices, and its memory must be initialized exactly once per
 /// process. Both are handled by a shim compiled into our libdds build
 /// (scripts/dds_compare/dds_shim.cpp): once-only init via std::call_once
-/// and a round-robin atomic thread-index dispenser. Safe for up to 16
-/// concurrently solving isolates; beyond that, indices can collide.
+/// and exclusive acquire/release thread-index slots. Every solve
+/// brackets its SolveBoard call with acquire/release (safe: the native
+/// call is synchronous, so an isolate can't abandon a held slot); if all
+/// slots are busy, solve() returns null and the caller falls back to the
+/// pure-Dart solver.
 library;
 
 import 'dart:ffi';
@@ -56,6 +59,8 @@ typedef _VoidC = Void Function();
 typedef _VoidDart = void Function();
 typedef _IntC = Int32 Function();
 typedef _IntDart = int Function();
+typedef _ReleaseC = Void Function(Int32);
+typedef _ReleaseDart = void Function(int);
 typedef _SolveBoardC = Int32 Function(
     _DdsDeal, Int32, Int32, Int32, Pointer<_DdsFutureTricks>, Int32);
 typedef _SolveBoardDart = int Function(
@@ -66,12 +71,14 @@ int _ddsRank(Rank r) => r.index + 2;
 
 class DdsBackend {
   final _SolveBoardDart _solveBoard;
+  final _IntDart _acquireThreadIndex;
+  final _ReleaseDart _releaseThreadIndex;
   final Pointer<_DdsDeal> _deal;
   final Pointer<_DdsFutureTricks> _fut;
-  final int _threadIndex;
   int nodesSearched = 0;
 
-  DdsBackend._(this._solveBoard, this._deal, this._fut, this._threadIndex);
+  DdsBackend._(this._solveBoard, this._acquireThreadIndex,
+      this._releaseThreadIndex, this._deal, this._fut);
 
   static DdsBackend? _instance;
   static bool _loadAttempted = false;
@@ -93,20 +100,22 @@ class DdsBackend {
     try {
       final lib = DynamicLibrary.open(path);
       // These come from dds_shim.cpp in our libdds build: process-wide
-      // once-only initialization and a round-robin thread index, so
-      // multiple isolates can use the library safely (see the threading
-      // note above).
+      // once-only initialization and exclusive thread-index slots (see
+      // the threading note above).
       final ensureInit = lib.lookupFunction<_VoidC, _VoidDart>("DdsEnsureInit");
-      final nextThreadIndex =
-          lib.lookupFunction<_IntC, _IntDart>("DdsNextThreadIndex");
+      final acquire =
+          lib.lookupFunction<_IntC, _IntDart>("DdsAcquireThreadIndex");
+      final release = lib
+          .lookupFunction<_ReleaseC, _ReleaseDart>("DdsReleaseThreadIndex");
       final solveBoard =
           lib.lookupFunction<_SolveBoardC, _SolveBoardDart>("SolveBoard");
       ensureInit();
       return DdsBackend._(
         solveBoard,
+        acquire,
+        release,
         calloc<_DdsDeal>(),
         calloc<_DdsFutureTricks>(),
-        nextThreadIndex(),
       );
     } catch (e) {
       return null;
@@ -139,7 +148,16 @@ class DdsBackend {
         totalCards++;
       }
     }
-    final res = _solveBoard(deal, -1, 1, 1, _fut, _threadIndex);
+    final threadIndex = _acquireThreadIndex();
+    if (threadIndex < 0) {
+      return null; // all DDS slots busy; caller falls back
+    }
+    final int res;
+    try {
+      res = _solveBoard(deal, -1, 1, 1, _fut, threadIndex);
+    } finally {
+      _releaseThreadIndex(threadIndex);
+    }
     if (res != 1) {
       return null;
     }

--- a/lib/bridge/dds_ffi.dart
+++ b/lib/bridge/dds_ffi.dart
@@ -99,6 +99,7 @@ class DdsBackend {
   static DdsBackend? _tryLoad(String path) {
     try {
       final lib = DynamicLibrary.open(path);
+      print("DDS backend loaded from $path");
       // These come from dds_shim.cpp in our libdds build: process-wide
       // once-only initialization and exclusive thread-index slots (see
       // the threading note above).
@@ -118,6 +119,11 @@ class DdsBackend {
         calloc<_DdsFutureTricks>(),
       );
     } catch (e) {
+      // Opt-in path (DDS_LIB was set), so a failure is worth reporting.
+      // Common causes: a relative path (the app's working directory is
+      // not the repo — use an absolute path) and the macOS app sandbox
+      // blocking dlopen outside the bundle.
+      print("DDS backend failed to load from $path: $e");
       return null;
     }
   }

--- a/lib/bridge/dds_ffi.dart
+++ b/lib/bridge/dds_ffi.dart
@@ -1,0 +1,152 @@
+/// Dart FFI binding to the dds-bridge/dds double-dummy solver (v2.9.0),
+/// used as an optional fast backend for MCDD's exact evaluations. Build
+/// the library with scripts/dds_compare/build_libdds.sh and opt in by
+/// setting the DDS_LIB environment variable to its path (each isolate
+/// loads it independently; loading is a no-op when the variable is unset
+/// or the library is missing, and callers fall back to the pure-Dart
+/// DDSolver).
+///
+/// Threading: DDS is thread-safe only when concurrent calls use distinct
+/// thread indices, and its memory must be initialized exactly once per
+/// process. Both are handled by a shim compiled into our libdds build
+/// (scripts/dds_compare/dds_shim.cpp): once-only init via std::call_once
+/// and a round-robin atomic thread-index dispenser. Safe for up to 16
+/// concurrently solving isolates; beyond that, indices can collide.
+library;
+
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:ffi/ffi.dart';
+
+import '../cards/card.dart';
+
+// DDS conventions: hands 0=N 1=E 2=S 3=W; suits 0=S 1=H 2=D 3=C;
+// trump 0..3 as suits, 4 = notrump; ranks 2..14; card masks bits 2..14.
+
+final class _DdsDeal extends Struct {
+  @Int32()
+  external int trump;
+  @Int32()
+  external int first;
+  @Array(3)
+  external Array<Int32> currentTrickSuit;
+  @Array(3)
+  external Array<Int32> currentTrickRank;
+  @Array(4, 4)
+  external Array<Array<Uint32>> remainCards;
+}
+
+final class _DdsFutureTricks extends Struct {
+  @Int32()
+  external int nodes;
+  @Int32()
+  external int cards;
+  @Array(13)
+  external Array<Int32> suit;
+  @Array(13)
+  external Array<Int32> rank;
+  @Array(13)
+  external Array<Int32> equals;
+  @Array(13)
+  external Array<Int32> score;
+}
+
+typedef _VoidC = Void Function();
+typedef _VoidDart = void Function();
+typedef _IntC = Int32 Function();
+typedef _IntDart = int Function();
+typedef _SolveBoardC = Int32 Function(
+    _DdsDeal, Int32, Int32, Int32, Pointer<_DdsFutureTricks>, Int32);
+typedef _SolveBoardDart = int Function(
+    _DdsDeal, int, int, int, Pointer<_DdsFutureTricks>, int);
+
+int _ddsSuit(Suit s) => 3 - s.index;
+int _ddsRank(Rank r) => r.index + 2;
+
+class DdsBackend {
+  final _SolveBoardDart _solveBoard;
+  final Pointer<_DdsDeal> _deal;
+  final Pointer<_DdsFutureTricks> _fut;
+  final int _threadIndex;
+  int nodesSearched = 0;
+
+  DdsBackend._(this._solveBoard, this._deal, this._fut, this._threadIndex);
+
+  static DdsBackend? _instance;
+  static bool _loadAttempted = false;
+
+  /// The process-wide backend, or null when unavailable. Loads lazily
+  /// from the DDS_LIB environment variable on first use.
+  static DdsBackend? get instance {
+    if (!_loadAttempted) {
+      _loadAttempted = true;
+      final path = Platform.environment["DDS_LIB"];
+      if (path != null && path.isNotEmpty) {
+        _instance = _tryLoad(path);
+      }
+    }
+    return _instance;
+  }
+
+  static DdsBackend? _tryLoad(String path) {
+    try {
+      final lib = DynamicLibrary.open(path);
+      // These come from dds_shim.cpp in our libdds build: process-wide
+      // once-only initialization and a round-robin thread index, so
+      // multiple isolates can use the library safely (see the threading
+      // note above).
+      final ensureInit = lib.lookupFunction<_VoidC, _VoidDart>("DdsEnsureInit");
+      final nextThreadIndex =
+          lib.lookupFunction<_IntC, _IntDart>("DdsNextThreadIndex");
+      final solveBoard =
+          lib.lookupFunction<_SolveBoardC, _SolveBoardDart>("SolveBoard");
+      ensureInit();
+      return DdsBackend._(
+        solveBoard,
+        calloc<_DdsDeal>(),
+        calloc<_DdsFutureTricks>(),
+        nextThreadIndex(),
+      );
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /// North-South tricks from this position with optimal play, including
+  /// the trick in progress — the same contract as [DDSolver.solve].
+  /// Returns null on a DDS error.
+  int? solve(List<List<PlayingCard>> hands, Suit? trump, int leader,
+      List<PlayingCard> trickCards) {
+    final deal = _deal.ref;
+    deal.trump = trump == null ? 4 : _ddsSuit(trump);
+    deal.first = leader;
+    for (int i = 0; i < 3; i++) {
+      deal.currentTrickSuit[i] = 0;
+      deal.currentTrickRank[i] = 0;
+    }
+    for (int i = 0; i < trickCards.length; i++) {
+      deal.currentTrickSuit[i] = _ddsSuit(trickCards[i].suit);
+      deal.currentTrickRank[i] = _ddsRank(trickCards[i].rank);
+    }
+    int totalCards = trickCards.length;
+    for (int h = 0; h < 4; h++) {
+      for (int s = 0; s < 4; s++) {
+        deal.remainCards[h][s] = 0;
+      }
+      for (final c in hands[h]) {
+        deal.remainCards[h][_ddsSuit(c.suit)] |= 1 << _ddsRank(c.rank);
+        totalCards++;
+      }
+    }
+    final res = _solveBoard(deal, -1, 1, 1, _fut, _threadIndex);
+    if (res != 1) {
+      return null;
+    }
+    nodesSearched += _fut.ref.nodes;
+    final score = _fut.ref.score[0];
+    final mover = (leader + trickCards.length) % 4;
+    final remainingTricks = totalCards ~/ 4;
+    return mover % 2 == 0 ? score : remainingTricks - score;
+  }
+}

--- a/lib/bridge/dds_ffi.dart
+++ b/lib/bridge/dds_ffi.dart
@@ -1,10 +1,11 @@
 /// Dart FFI binding to the dds-bridge/dds double-dummy solver (v2.9.0),
 /// used as an optional fast backend for MCDD's exact evaluations. Build
-/// the library with scripts/dds_compare/build_libdds.sh and opt in by
-/// setting the DDS_LIB environment variable to its path (each isolate
-/// loads it independently; loading is a no-op when the variable is unset
-/// or the library is missing, and callers fall back to the pure-Dart
-/// DDSolver).
+/// the library with scripts/dds_compare/build_libdds.sh; it is loaded
+/// from the platform default location when present (macOS: bundled in
+/// Contents/Frameworks by a Runner build phase; Android: libdds.so from
+/// jniLibs), and the DDS_LIB environment variable overrides the path for
+/// development. When no library can be loaded, callers fall back to the
+/// pure-Dart DDSolver. Each isolate loads independently.
 ///
 /// Threading: DDS is thread-safe only when concurrent calls use distinct
 /// thread indices, and its memory must be initialized exactly once per
@@ -83,20 +84,30 @@ class DdsBackend {
   static DdsBackend? _instance;
   static bool _loadAttempted = false;
 
-  /// The process-wide backend, or null when unavailable. Loads lazily
-  /// from the DDS_LIB environment variable on first use.
+  /// The process-wide backend, or null when unavailable. Loads lazily on
+  /// first use: the DDS_LIB environment variable if set, otherwise the
+  /// platform's default bundled location.
   static DdsBackend? get instance {
     if (!_loadAttempted) {
       _loadAttempted = true;
-      final path = Platform.environment["DDS_LIB"];
-      if (path != null && path.isNotEmpty) {
-        _instance = _tryLoad(path);
+      final envPath = Platform.environment["DDS_LIB"];
+      if (envPath != null && envPath.isNotEmpty) {
+        _instance = _tryLoad(envPath, verbose: true);
+      } else if (Platform.isAndroid) {
+        // The loader resolves bare names against the app's jniLibs.
+        _instance = _tryLoad("libdds.so", verbose: false);
+      } else if (Platform.isMacOS) {
+        final path = "${File(Platform.resolvedExecutable).parent.path}"
+            "/../Frameworks/libdds.dylib";
+        if (File(path).existsSync()) {
+          _instance = _tryLoad(path, verbose: false);
+        }
       }
     }
     return _instance;
   }
 
-  static DdsBackend? _tryLoad(String path) {
+  static DdsBackend? _tryLoad(String path, {required bool verbose}) {
     try {
       final lib = DynamicLibrary.open(path);
       print("DDS backend loaded from $path");
@@ -119,11 +130,13 @@ class DdsBackend {
         calloc<_DdsFutureTricks>(),
       );
     } catch (e) {
-      // Opt-in path (DDS_LIB was set), so a failure is worth reporting.
-      // Common causes: a relative path (the app's working directory is
-      // not the repo — use an absolute path) and the macOS app sandbox
-      // blocking dlopen outside the bundle.
-      print("DDS backend failed to load from $path: $e");
+      if (verbose) {
+        // DDS_LIB was set explicitly, so a failure is worth reporting.
+        // Common causes: a relative path (the app's working directory is
+        // not the repo — use an absolute path) and the macOS app sandbox
+        // blocking dlopen outside the bundle in sandboxed builds.
+        print("DDS backend failed to load from $path: $e");
+      }
       return null;
     }
   }

--- a/lib/bridge/play_strategies.dart
+++ b/lib/bridge/play_strategies.dart
@@ -17,6 +17,8 @@
 ///                              heuristic preroll, then double-dummy solve.
 ///     rounds=N, ms=N, bid/nobid  as for mc (bid defaults ON here)
 ///     dd=K                       tricks left at which to solve (default 8)
+///     nodds                      don't use the native dds backend even if
+///                                DDS_LIB is set (see dds_ffi.dart)
 ///     margin=X, dmargin=X        honor-waste guard margins (points/deal)
 ///                                for declarer / defenders; an unsupported
 ///                                K/Q lead defers to the heuristic unless
@@ -101,6 +103,7 @@ PlayStrategy makeStrategy(String spec) {
       final margin = double.parse(options["margin"] ?? "5");
       final dmargin = double.parse(options["dmargin"] ?? "18");
       final fullSolve = !options.containsKey("nofull");
+      final useDds = !options.containsKey("nodds");
       PlayingCard choose(CardToPlayRequest req, Random rng) {
         return chooseCardMonteCarloDD(req, rng,
                 maxRounds: maxRounds,
@@ -109,7 +112,8 @@ PlayStrategy makeStrategy(String spec) {
                 useBiddingInference: useBid,
                 equityMargin: margin,
                 defenderEquityMargin: dmargin,
-                tryFullDepthSolve: fullSolve)
+                tryFullDepthSolve: fullSolve,
+                useDdsBackend: useDds)
             .bestCard;
       }
       return PlayStrategy(spec, choose);

--- a/lib/bridge_ui.dart
+++ b/lib/bridge_ui.dart
@@ -15,6 +15,8 @@ import 'cards/card.dart';
 import 'cards/rollout.dart';
 import 'bridge/bridge.dart';
 import 'bridge/bridge_ai.dart';
+import 'bridge/dd_solver.dart';
+import 'bridge/dds_ffi.dart';
 
 const debugOutput = false;
 
@@ -38,6 +40,28 @@ PlayingCard computeCard(final CardToPlayRequest req) {
         chooseCardMonteCarlo(req, mcParams, chooseCardRandom, Random());
     return result.bestCard;
   }
+}
+
+class DdResultRequest {
+  final List<List<PlayingCard>> hands;
+  final Suit? trump;
+  final int leader;
+  final int declarer;
+
+  DdResultRequest(this.hands, this.trump, this.leader, this.declarer);
+}
+
+/// Tricks the declaring side takes double-dummy from the opening lead, or
+/// null if no solver can answer within budget. Run via compute().
+int? computeDoubleDummyDeclarerTricks(DdResultRequest req) {
+  int? ns =
+      DdsBackend.instance?.solve(req.hands, req.trump, req.leader, const []);
+  // Without the native backend a full-deal solve can be very slow; give
+  // the pure-Dart solver a bounded budget and omit the result on abort.
+  ns ??= DDSolver.fromHands(req.hands, req.trump, req.leader)
+      .solveWithNodeLimit(5000000);
+  if (ns == null) return null;
+  return req.declarer % 2 == 0 ? ns : 13 - ns;
 }
 
 class BridgeMatchDisplay extends StatefulWidget {
@@ -356,6 +380,33 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
     if (playerMoods.containsValue(Mood.mad)) {
       widget.soundPlayer.playMadSound();
     }
+  }
+
+  // Double-dummy result of the finished round's contract, computed once
+  // per round in a background isolate for the end-of-round dialog.
+  BridgeRound? _ddResultRound;
+  int? _ddDeclarerTricks;
+  bool _ddComputeInFlight = false;
+
+  void _ensureDoubleDummyResult() {
+    if (!round.isOver() || round.contract == null) return;
+    if (identical(_ddResultRound, round) || _ddComputeInFlight) return;
+    _ddComputeInFlight = true;
+    final target = round;
+    final req = DdResultRequest(
+      [for (int p = 0; p < 4; p++) target.originalHandForPlayer(p)],
+      target.contract!.bid.trump,
+      (target.contract!.declarer + 1) % 4,
+      target.contract!.declarer,
+    );
+    compute(computeDoubleDummyDeclarerTricks, req).then((tricks) {
+      _ddComputeInFlight = false;
+      if (!mounted) return;
+      setState(() {
+        _ddResultRound = target;
+        _ddDeclarerTricks = tricks;
+      });
+    });
   }
 
   // Set when the human's round ends; stats are recorded once both the
@@ -836,6 +887,7 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
   @override
   Widget build(BuildContext context) {
     final layout = computeLayout(context);
+    _ensureDoubleDummyResult();
     final showAllHands = false;
 
     return Stack(
@@ -866,6 +918,8 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
             layout: layout,
             match: match,
             duplicateRound: duplicateRound,
+            doubleDummyDeclarerTricks:
+                identical(_ddResultRound, round) ? _ddDeclarerTricks : null,
             onContinue: () => setState(_startRound),
             onMainMenu: _showMainMenuAfterMatch,
             onReplayDuplicateRound: _runDuplicateRound,
@@ -1225,6 +1279,8 @@ class EndOfRoundDialog extends StatelessWidget {
   final Layout layout;
   final BridgeMatch match;
   final BridgeRound duplicateRound;
+  // Declarer-side tricks with best play by everyone, if computed.
+  final int? doubleDummyDeclarerTricks;
   final Function() onContinue;
   final Function() onMainMenu;
   // For testing to see how the AI plays the hand over multiple runs.
@@ -1235,6 +1291,7 @@ class EndOfRoundDialog extends StatelessWidget {
     required this.layout,
     required this.match,
     required this.duplicateRound,
+    this.doubleDummyDeclarerTricks,
     required this.onContinue,
     required this.onMainMenu,
     this.onReplayDuplicateRound,
@@ -1323,6 +1380,16 @@ class EndOfRoundDialog extends StatelessWidget {
                           child: Text("$roundResultDesc: ${formatRoundScore(round)}",
                               style: const TextStyle(fontSize: 18))),
                     ]),
+                    if (doubleDummyDeclarerTricks != null)
+                      makeRow([
+                        Padding(
+                            padding: const EdgeInsets.only(bottom: 8),
+                            child: Text(
+                                "Double dummy: ${contractResultDescription(round.contract!, doubleDummyDeclarerTricks!)}",
+                                style: TextStyle(
+                                    fontSize: 13,
+                                    color: Colors.grey.shade700))),
+                      ]),
                     makeRow([
                       const Padding(
                         padding: EdgeInsets.only(),
@@ -1375,6 +1442,12 @@ class EndOfRoundDialog extends StatelessWidget {
           Opacity(opacity: val.clamp(0.0, 1.0), child: child),
     );
   }
+}
+
+/// "made 4" / "down 2" for taking [tricks] against [contract].
+String contractResultDescription(Contract contract, int tricks) {
+  final over = tricks - contract.bid.numTricksRequired;
+  return over >= 0 ? "made ${over + contract.bid.count}" : "down ${-over}";
 }
 
 String roundResultDescription(BridgeRound round) {

--- a/lib/bridge_ui.dart
+++ b/lib/bridge_ui.dart
@@ -1376,7 +1376,7 @@ class EndOfRoundDialog extends StatelessWidget {
                     ]),
                     makeRow([
                       Padding(
-                          padding: const EdgeInsets.all(10),
+                          padding: const EdgeInsets.only(top: 10, left: 10, right: 10),
                           child: Text("$roundResultDesc: ${formatRoundScore(round)}",
                               style: const TextStyle(fontSize: 18))),
                     ]),
@@ -1386,9 +1386,7 @@ class EndOfRoundDialog extends StatelessWidget {
                             padding: const EdgeInsets.only(bottom: 8),
                             child: Text(
                                 "Double dummy: ${contractResultDescription(round.contract!, doubleDummyDeclarerTricks!)}",
-                                style: TextStyle(
-                                    fontSize: 13,
-                                    color: Colors.grey.shade700))),
+                                style: const TextStyle(fontSize: 11))),
                       ]),
                     makeRow([
                       const Padding(

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -212,6 +212,7 @@
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
+				DD5C0DE50000000000000001 /* Embed libdds */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
 			);
 			buildRules = (
@@ -301,6 +302,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		DD5C0DE50000000000000001 /* Embed libdds */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed libdds";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "DYLIB=\"$SRCROOT/../native/libdds.dylib\"\nDEST=\"$BUILT_PRODUCTS_DIR/$FRAMEWORKS_FOLDER_PATH\"\nif [ -f \"$DYLIB\" ]; then\n  mkdir -p \"$DEST\"\n  cp \"$DYLIB\" \"$DEST/libdds.dylib\"\n  codesign --force --sign \"${EXPANDED_CODE_SIGN_IDENTITY:--}\" \"$DEST/libdds.dylib\"\nfi\n";
+		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<true/>
+	<false/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -90,7 +90,7 @@ packages:
     source: hosted
     version: "1.3.3"
   ffi:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: ffi
       sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   path: ^1.8.2
   path_provider: ^2.0.10
   just_audio: ^0.9.28
+  ffi: ^2.2.0
 
 dev_dependencies:
   flutter_test:

--- a/scripts/dds_compare/build_libdds.sh
+++ b/scripts/dds_compare/build_libdds.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Builds libdds (dds-bridge/dds v2.9.0) as a dynamic library for use via
+# Dart FFI (lib/bridge/dds_ffi.dart). Usage:
+#   sh scripts/dds_compare/build_libdds.sh [output-dir]
+# Clones the source into a temporary directory if a checkout isn't given
+# via DDS_SRC, and writes libdds.dylib (macOS) or libdds.so (Linux) into
+# the output dir (default: native/).
+set -e
+OUT_DIR="${1:-native}"
+mkdir -p "$OUT_DIR"
+if [ -z "$DDS_SRC" ]; then
+  DDS_SRC="$(mktemp -d)/dds"
+  echo "Cloning dds v2.9.0 into $DDS_SRC"
+  git clone -q --depth 1 --branch v2.9.0 https://github.com/dds-bridge/dds.git "$DDS_SRC"
+fi
+case "$(uname)" in
+  Darwin) LIB="libdds.dylib"; SHARED="-dynamiclib" ;;
+  *) LIB="libdds.so"; SHARED="-shared -fPIC" ;;
+esac
+echo "Building $OUT_DIR/$LIB"
+SCRIPT_DIR="$(dirname "$0")"
+clang++ -O2 -std=c++11 -DDDS_THREADS_STL \
+  -I"$DDS_SRC/include" -I"$DDS_SRC/src" \
+  $SHARED "$DDS_SRC"/src/*.cpp "$SCRIPT_DIR/dds_shim.cpp" \
+  -o "$OUT_DIR/$LIB"
+echo "Done: $OUT_DIR/$LIB"

--- a/scripts/dds_compare/build_libdds.sh
+++ b/scripts/dds_compare/build_libdds.sh
@@ -1,26 +1,71 @@
 #!/bin/sh
-# Builds libdds (dds-bridge/dds v2.9.0) as a dynamic library for use via
-# Dart FFI (lib/bridge/dds_ffi.dart). Usage:
-#   sh scripts/dds_compare/build_libdds.sh [output-dir]
-# Clones the source into a temporary directory if a checkout isn't given
-# via DDS_SRC, and writes libdds.dylib (macOS) or libdds.so (Linux) into
-# the output dir (default: native/).
+# Builds libdds (dds-bridge/dds v2.9.0 plus dds_shim.cpp) for use via Dart
+# FFI (lib/bridge/dds_ffi.dart).
+#
+# Usage:
+#   sh scripts/dds_compare/build_libdds.sh           # host build -> native/
+#   sh scripts/dds_compare/build_libdds.sh macos     # host build AND copy
+#                                                    # where the macOS app
+#                                                    # build phase finds it
+#   sh scripts/dds_compare/build_libdds.sh android   # NDK cross-builds ->
+#                                                    # android/app/src/main/jniLibs/<abi>/
+#
+# The dds source is cloned to a temporary directory unless DDS_SRC points
+# at an existing checkout of tag v2.9.0. Android needs ANDROID_NDK_HOME or
+# an NDK under ~/Library/Android/sdk/ndk. Build outputs are gitignored;
+# run this script locally before building the app with dds support.
 set -e
-OUT_DIR="${1:-native}"
-mkdir -p "$OUT_DIR"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MODE="${1:-host}"
+
 if [ -z "$DDS_SRC" ]; then
   DDS_SRC="$(mktemp -d)/dds"
   echo "Cloning dds v2.9.0 into $DDS_SRC"
   git clone -q --depth 1 --branch v2.9.0 https://github.com/dds-bridge/dds.git "$DDS_SRC"
 fi
-case "$(uname)" in
-  Darwin) LIB="libdds.dylib"; SHARED="-dynamiclib" ;;
-  *) LIB="libdds.so"; SHARED="-shared -fPIC" ;;
+
+COMMON="-O2 -std=c++11 -DDDS_THREADS_STL -I$DDS_SRC/include -I$DDS_SRC/src"
+SOURCES="$DDS_SRC/src/*.cpp $SCRIPT_DIR/dds_shim.cpp"
+
+build_host() {
+  OUT_DIR="$REPO_DIR/native"
+  mkdir -p "$OUT_DIR"
+  case "$(uname)" in
+    Darwin) LIB="libdds.dylib"; SHARED="-dynamiclib" ;;
+    *) LIB="libdds.so"; SHARED="-shared -fPIC" ;;
+  esac
+  echo "Building $OUT_DIR/$LIB"
+  clang++ $COMMON $SHARED $SOURCES -o "$OUT_DIR/$LIB"
+}
+
+build_android() {
+  if [ -z "$ANDROID_NDK_HOME" ]; then
+    ANDROID_NDK_HOME="$(ls -d "$HOME"/Library/Android/sdk/ndk/* 2>/dev/null | sort -V | tail -1)"
+  fi
+  if [ -z "$ANDROID_NDK_HOME" ] || [ ! -d "$ANDROID_NDK_HOME" ]; then
+    echo "Android NDK not found; set ANDROID_NDK_HOME" >&2
+    exit 1
+  fi
+  TOOLCHAIN="$(ls -d "$ANDROID_NDK_HOME"/toolchains/llvm/prebuilt/*/bin | head -1)"
+  echo "Using NDK toolchain $TOOLCHAIN"
+  for ABI_TRIPLE in \
+      "arm64-v8a aarch64-linux-android21" \
+      "armeabi-v7a armv7a-linux-androideabi21" \
+      "x86_64 x86_64-linux-android21"; do
+    set -- $ABI_TRIPLE
+    ABI="$1"; TRIPLE="$2"
+    OUT_DIR="$REPO_DIR/android/app/src/main/jniLibs/$ABI"
+    mkdir -p "$OUT_DIR"
+    echo "Building $OUT_DIR/libdds.so"
+    "$TOOLCHAIN/clang++" --target="$TRIPLE" $COMMON -shared -fPIC \
+      -static-libstdc++ $SOURCES -o "$OUT_DIR/libdds.so"
+  done
+}
+
+case "$MODE" in
+  host|macos) build_host ;;
+  android) build_android ;;
+  *) echo "Unknown mode: $MODE (use host, macos, or android)" >&2; exit 1 ;;
 esac
-echo "Building $OUT_DIR/$LIB"
-SCRIPT_DIR="$(dirname "$0")"
-clang++ -O2 -std=c++11 -DDDS_THREADS_STL \
-  -I"$DDS_SRC/include" -I"$DDS_SRC/src" \
-  $SHARED "$DDS_SRC"/src/*.cpp "$SCRIPT_DIR/dds_shim.cpp" \
-  -o "$OUT_DIR/$LIB"
-echo "Done: $OUT_DIR/$LIB"
+echo "Done"

--- a/scripts/dds_compare/dds_check.dart
+++ b/scripts/dds_compare/dds_check.dart
@@ -127,6 +127,7 @@ void main(List<String> args) async {
 
   // Solve ours.
   final ourNs = <int>[];
+  int ourNodes = 0;
   final ourWatch = Stopwatch()..start();
   for (final p in positions) {
     final solver = DDSolver.fromHands(p.hands, p.trump, p.leader);
@@ -134,6 +135,7 @@ void main(List<String> args) async {
       solver.addTrickCard(c);
     }
     ourNs.add(solver.solve());
+    ourNodes += solver.nodesSearched;
   }
   ourWatch.stop();
 
@@ -157,6 +159,7 @@ void main(List<String> args) async {
   }
 
   int mismatches = 0;
+  int ddsNodes = 0;
   for (int i = 0; i < positions.length; i++) {
     final p = positions[i];
     if (ddsOut[i].startsWith("ERR")) {
@@ -164,7 +167,9 @@ void main(List<String> args) async {
       mismatches++;
       continue;
     }
-    final score = int.parse(ddsOut[i]);
+    final ddsParts = ddsOut[i].split(" ");
+    final score = int.parse(ddsParts[0]);
+    ddsNodes += int.parse(ddsParts[1]);
     final mover = (p.leader + p.trickCards.length) % 4;
     final ddsNs = mover % 2 == 0 ? score : p.depth - score;
     if (ddsNs != ourNs[i]) {
@@ -178,5 +183,9 @@ void main(List<String> args) async {
       "$mismatches mismatches");
   print("time: ours ${ourWatch.elapsedMilliseconds}ms, "
       "dds ${ddsWatch.elapsedMilliseconds}ms");
+  print("nodes: ours $ourNodes, dds $ddsNodes "
+      "(ratio ${(ourNodes / max(1, ddsNodes)).toStringAsFixed(1)}x); "
+      "ns/node: ours ${(ourWatch.elapsedMicroseconds * 1000 / max(1, ourNodes)).toStringAsFixed(0)}, "
+      "dds ${(ddsWatch.elapsedMicroseconds * 1000 / max(1, ddsNodes)).toStringAsFixed(0)}");
   exit(mismatches == 0 ? 0 : 1);
 }

--- a/scripts/dds_compare/dds_check.dart
+++ b/scripts/dds_compare/dds_check.dart
@@ -1,0 +1,182 @@
+/// Cross-checks lib/bridge/dd_solver.dart against the established
+/// dds-bridge/dds solver on randomly generated positions. Double dummy is
+/// a perfect-information problem, so any two correct solvers must agree
+/// exactly on every position.
+///
+/// Build the driver first (see dds_driver.cpp), then:
+///   dart run scripts/dds_compare/dds_check.dart --driver <path> \
+///       [--trials N] [--mindepth N] [--maxdepth N] [--seed N]
+///
+/// Positions get random trumps and leaders, and ~40% include a partial
+/// trick of 1-3 legal cards. DDS reports tricks for the side of the
+/// player to move; ours reports North-South tricks including the trick
+/// in progress. Both are normalized to North-South for comparison.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:cards_with_cats/bridge/dd_solver.dart';
+import 'package:cards_with_cats/cards/card.dart';
+
+int ddsSuit(Suit s) => 3 - s.index; // DDS: 0=S 1=H 2=D 3=C
+int ddsRank(Rank r) => r.index + 2; // DDS: 2..14
+
+class Position {
+  final List<List<PlayingCard>> hands; // remaining, after trick cards
+  final Suit? trump;
+  final int leader;
+  final List<PlayingCard> trickCards;
+
+  Position(this.hands, this.trump, this.leader, this.trickCards);
+
+  int get depth =>
+      (hands.fold(0, (n, h) => n + h.length) + trickCards.length) ~/ 4;
+
+  String toDriverLine() {
+    final parts = <int>[
+      trump == null ? 4 : ddsSuit(trump!),
+      leader,
+      trickCards.length,
+      for (final c in trickCards) ...[ddsSuit(c.suit), ddsRank(c.rank)],
+    ];
+    for (int h = 0; h < 4; h++) {
+      for (int s = 0; s < 4; s++) {
+        final suit = Suit.values[3 - s];
+        int mask = 0;
+        for (final c in hands[h]) {
+          if (c.suit == suit) mask |= 1 << ddsRank(c.rank);
+        }
+        parts.add(mask);
+      }
+    }
+    return parts.join(" ");
+  }
+
+  @override
+  String toString() {
+    final handStr = [
+      for (int h = 0; h < 4; h++)
+        "${"NESW"[h]}: ${PlayingCard.stringFromCards(hands[h])}"
+    ].join("  ");
+    return "trump=${trump?.asciiChar ?? 'NT'} leader=${"NESW"[leader]} "
+        "trick=[${PlayingCard.stringFromCards(trickCards)}] $handStr";
+  }
+}
+
+Position randomPosition(Random rng, int minDepth, int maxDepth) {
+  final depth = minDepth + rng.nextInt(maxDepth - minDepth + 1);
+  final deck = List.of(standardDeckCards())..shuffle(rng);
+  final hands = [
+    for (int h = 0; h < 4; h++) deck.sublist(h * depth, (h + 1) * depth)
+  ];
+  final trumpChoice = rng.nextInt(5);
+  final trump = trumpChoice == 4 ? null : Suit.values[trumpChoice];
+  final leader = rng.nextInt(4);
+  final trickCards = <PlayingCard>[];
+  if (rng.nextDouble() < 0.4) {
+    final numTrickCards = 1 + rng.nextInt(3);
+    for (int i = 0; i < numTrickCards; i++) {
+      final seat = (leader + i) % 4;
+      final hand = hands[seat];
+      List<PlayingCard> legal = hand;
+      if (trickCards.isNotEmpty) {
+        final ledSuit = trickCards[0].suit;
+        final following = hand.where((c) => c.suit == ledSuit).toList();
+        if (following.isNotEmpty) legal = following;
+      }
+      final card = legal[rng.nextInt(legal.length)];
+      hand.remove(card);
+      trickCards.add(card);
+    }
+  }
+  return Position(hands, trump, leader, trickCards);
+}
+
+void main(List<String> args) async {
+  String? driverPath;
+  int trials = 2000;
+  int seed = 42;
+  int minDepth = 2;
+  int maxDepth = 8;
+  for (int i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--driver":
+        driverPath = args[++i];
+      case "--trials":
+        trials = int.parse(args[++i]);
+      case "--seed":
+        seed = int.parse(args[++i]);
+      case "--mindepth":
+        minDepth = int.parse(args[++i]);
+      case "--maxdepth":
+        maxDepth = int.parse(args[++i]);
+    }
+  }
+  if (driverPath == null) {
+    print("--driver <path to dds_driver binary> is required "
+        "(see dds_driver.cpp for build instructions)");
+    exit(1);
+  }
+
+  final rng = Random(seed);
+  final positions = [
+    for (int i = 0; i < trials; i++) randomPosition(rng, minDepth, maxDepth)
+  ];
+
+  // Solve ours.
+  final ourNs = <int>[];
+  final ourWatch = Stopwatch()..start();
+  for (final p in positions) {
+    final solver = DDSolver.fromHands(p.hands, p.trump, p.leader);
+    for (final c in p.trickCards) {
+      solver.addTrickCard(c);
+    }
+    ourNs.add(solver.solve());
+  }
+  ourWatch.stop();
+
+  // Solve with DDS via the driver.
+  final ddsWatch = Stopwatch()..start();
+  final proc = await Process.start(driverPath, []);
+  final outLines = proc.stdout
+      .transform(const SystemEncoding().decoder)
+      .transform(const LineSplitter())
+      .toList();
+  for (final p in positions) {
+    proc.stdin.writeln(p.toDriverLine());
+  }
+  await proc.stdin.close();
+  final ddsOut = await outLines;
+  ddsWatch.stop();
+  if (ddsOut.length != positions.length) {
+    print("DDS driver returned ${ddsOut.length} lines for "
+        "${positions.length} positions");
+    exit(1);
+  }
+
+  int mismatches = 0;
+  for (int i = 0; i < positions.length; i++) {
+    final p = positions[i];
+    if (ddsOut[i].startsWith("ERR")) {
+      print("DDS error on position $i: ${ddsOut[i]}\n  $p");
+      mismatches++;
+      continue;
+    }
+    final score = int.parse(ddsOut[i]);
+    final mover = (p.leader + p.trickCards.length) % 4;
+    final ddsNs = mover % 2 == 0 ? score : p.depth - score;
+    if (ddsNs != ourNs[i]) {
+      mismatches++;
+      print("MISMATCH position $i: ours=${ourNs[i]} dds=$ddsNs");
+      print("  $p");
+      print("  driver line: ${p.toDriverLine()}");
+    }
+  }
+  print("$trials positions (depth $minDepth-$maxDepth), "
+      "$mismatches mismatches");
+  print("time: ours ${ourWatch.elapsedMilliseconds}ms, "
+      "dds ${ddsWatch.elapsedMilliseconds}ms");
+  exit(mismatches == 0 ? 0 : 1);
+}

--- a/scripts/dds_compare/dds_driver.cpp
+++ b/scripts/dds_compare/dds_driver.cpp
@@ -1,0 +1,56 @@
+// Batch driver for cross-checking lib/bridge/dd_solver.dart against the
+// established dds-bridge/dds solver (tested with v2.9.0).
+//
+// Build (from a checkout of dds-bridge/dds at tag v2.9.0):
+//   clang++ -O2 -std=c++11 -DDDS_THREADS_STL -I<dds>/include \
+//       scripts/dds_compare/dds_driver.cpp <dds>/src/*.cpp -o dds_driver
+//
+// Protocol: one position per input line, all numbers decimal:
+//   trump first ntrick [suit rank]*ntrick m00 m01 ... m33
+// where trump is 0=S 1=H 2=D 3=C 4=NT, first is the leader of the current
+// trick (0=N 1=E 2=S 3=W), ntrick in 0..3 is the number of cards already
+// played to the trick (suit/rank pairs in play order, rank 2..14), and mHS
+// is the DDS bitmask (bits 2..14) of hand H's remaining cards in suit S,
+// suits in DDS order S,H,D,C.
+// Output: one line per position with the maximum tricks for the side of
+// the player to move, or "ERR <code>".
+
+#include <cstdio>
+#include <string>
+#include "dll.h"
+
+int main() {
+  SetMaxThreads(1);
+  struct deal dl;
+  struct futureTricks fut;
+  int trump, first, ntrick;
+  while (scanf("%d %d %d", &trump, &first, &ntrick) == 3) {
+    dl.trump = trump;
+    dl.first = first;
+    for (int i = 0; i < 3; i++) {
+      dl.currentTrickSuit[i] = 0;
+      dl.currentTrickRank[i] = 0;
+    }
+    for (int i = 0; i < ntrick; i++) {
+      if (scanf("%d %d", &dl.currentTrickSuit[i], &dl.currentTrickRank[i]) != 2) {
+        return 1;
+      }
+    }
+    for (int h = 0; h < DDS_HANDS; h++) {
+      for (int s = 0; s < DDS_SUITS; s++) {
+        if (scanf("%u", &dl.remainCards[h][s]) != 1) {
+          return 1;
+        }
+      }
+    }
+    const int res = SolveBoard(dl, /*target=*/-1, /*solutions=*/1,
+                               /*mode=*/1, &fut, /*threadIndex=*/0);
+    if (res != RETURN_NO_FAULT) {
+      printf("ERR %d\n", res);
+    } else {
+      printf("%d\n", fut.score[0]);
+    }
+    fflush(stdout);
+  }
+  return 0;
+}

--- a/scripts/dds_compare/dds_driver.cpp
+++ b/scripts/dds_compare/dds_driver.cpp
@@ -13,7 +13,7 @@
 // is the DDS bitmask (bits 2..14) of hand H's remaining cards in suit S,
 // suits in DDS order S,H,D,C.
 // Output: one line per position with the maximum tricks for the side of
-// the player to move, or "ERR <code>".
+// the player to move and the nodes searched, or "ERR <code>".
 
 #include <cstdio>
 #include <string>
@@ -48,7 +48,7 @@ int main() {
     if (res != RETURN_NO_FAULT) {
       printf("ERR %d\n", res);
     } else {
-      printf("%d\n", fut.score[0]);
+      printf("%d %d\n", fut.score[0], fut.nodes);
     }
     fflush(stdout);
   }

--- a/scripts/dds_compare/dds_ffi_check.dart
+++ b/scripts/dds_compare/dds_ffi_check.dart
@@ -1,0 +1,69 @@
+/// Validates the FFI binding (lib/bridge/dds_ffi.dart) against our
+/// DDSolver on random positions — this checks struct layout and score
+/// mapping, on top of the solver-vs-solver agreement already established
+/// via the driver harness.
+///
+///   DDS_LIB=native/libdds.dylib dart run scripts/dds_compare/dds_ffi_check.dart \
+///       [--trials N] [--mindepth N] [--maxdepth N] [--seed N]
+library;
+
+import 'dart:io';
+import 'dart:math';
+
+import 'package:cards_with_cats/bridge/dd_solver.dart';
+import 'package:cards_with_cats/bridge/dds_ffi.dart';
+
+import 'dds_check.dart' show Position, randomPosition;
+
+void main(List<String> args) {
+  int trials = 2000;
+  int seed = 42;
+  int minDepth = 2;
+  int maxDepth = 8;
+  for (int i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--trials":
+        trials = int.parse(args[++i]);
+      case "--seed":
+        seed = int.parse(args[++i]);
+      case "--mindepth":
+        minDepth = int.parse(args[++i]);
+      case "--maxdepth":
+        maxDepth = int.parse(args[++i]);
+    }
+  }
+  final dds = DdsBackend.instance;
+  if (dds == null) {
+    print("DDS backend unavailable; set DDS_LIB to the built library "
+        "(scripts/dds_compare/build_libdds.sh)");
+    exit(1);
+  }
+
+  final rng = Random(seed);
+  int mismatches = 0;
+  final ourWatch = Stopwatch();
+  final ddsWatch = Stopwatch();
+  for (int i = 0; i < trials; i++) {
+    final Position p = randomPosition(rng, minDepth, maxDepth);
+    ourWatch.start();
+    final solver = DDSolver.fromHands(p.hands, p.trump, p.leader);
+    for (final c in p.trickCards) {
+      solver.addTrickCard(c);
+    }
+    final ours = solver.solve();
+    ourWatch.stop();
+    ddsWatch.start();
+    final ffi = dds.solve(p.hands, p.trump, p.leader, p.trickCards);
+    ddsWatch.stop();
+    if (ffi != ours) {
+      mismatches++;
+      print("MISMATCH: ours=$ours ffi=$ffi\n  $p");
+    }
+  }
+  print("$trials positions (depth $minDepth-$maxDepth), "
+      "$mismatches mismatches");
+  print("time: ours ${ourWatch.elapsedMilliseconds}ms, "
+      "dds-ffi ${ddsWatch.elapsedMilliseconds}ms "
+      "(dds nodes ${dds.nodesSearched})");
+  exit(mismatches == 0 ? 0 : 1);
+}

--- a/scripts/dds_compare/dds_isolate_probe.dart
+++ b/scripts/dds_compare/dds_isolate_probe.dart
@@ -1,0 +1,21 @@
+/// Probes DdsBackend behavior across isolates (see dds_ffi threading note).
+library;
+
+import 'dart:isolate';
+
+import 'package:cards_with_cats/bridge/dds_ffi.dart';
+import 'package:cards_with_cats/cards/card.dart';
+
+const c = PlayingCard.cardsFromString;
+
+int? solveOnce() {
+  final hands = [c("AS KS QS JS"), c("8H 7H 6H 5H"), c("8D 7D 6D 5D"), c("8C 7C 6C 5C")];
+  return DdsBackend.instance?.solve(hands, null, 0, []);
+}
+
+void main() async {
+  print("main isolate: ${solveOnce()}");
+  print("worker 1: ${await Isolate.run(solveOnce)}");
+  print("worker 2: ${await Isolate.run(solveOnce)}");
+  print("main again: ${solveOnce()}");
+}

--- a/scripts/dds_compare/dds_shim.cpp
+++ b/scripts/dds_compare/dds_shim.cpp
@@ -27,7 +27,13 @@ static int usableThreads = 0;
 extern "C" void DdsEnsureInit() {
   static std::once_flag flag;
   std::call_once(flag, [] {
+#ifdef __ANDROID__
+    // On mobile, bound total memory: DDS otherwise sizes its per-thread
+    // transposition tables from free RAM (up to 160MB per thread).
+    SetResources(256, DDS_SHIM_MAX_THREADS);
+#else
     SetMaxThreads(DDS_SHIM_MAX_THREADS);
+#endif
     DDSInfo info;
     GetDDSInfo(&info);
     usableThreads = info.noOfThreads;

--- a/scripts/dds_compare/dds_shim.cpp
+++ b/scripts/dds_compare/dds_shim.cpp
@@ -1,0 +1,27 @@
+// Small shim compiled into our libdds build (see build_libdds.sh) to make
+// the library safe to use from multiple Dart isolates in one process:
+// - DdsEnsureInit initializes thread memory exactly once process-wide
+//   (calling SetMaxThreads again from a later isolate resets state under
+//   in-flight or subsequent solves; GetDDSInfo can't be used to probe
+//   because it crashes on an uninitialized library).
+// - DdsNextThreadIndex hands out round-robin thread indices, so isolates
+//   created within a window of DDS_SHIM_THREADS of each other never share
+//   an index. Concurrent solves are safe as long as no more than
+//   DDS_SHIM_THREADS isolates are in flight at once.
+
+#include <atomic>
+#include <mutex>
+
+#include "dll.h"
+
+#define DDS_SHIM_THREADS 16
+
+extern "C" void DdsEnsureInit() {
+  static std::once_flag flag;
+  std::call_once(flag, [] { SetMaxThreads(DDS_SHIM_THREADS); });
+}
+
+extern "C" int DdsNextThreadIndex() {
+  static std::atomic<int> counter{0};
+  return counter.fetch_add(1) % DDS_SHIM_THREADS;
+}

--- a/scripts/dds_compare/dds_shim.cpp
+++ b/scripts/dds_compare/dds_shim.cpp
@@ -1,27 +1,51 @@
 // Small shim compiled into our libdds build (see build_libdds.sh) to make
 // the library safe to use from multiple Dart isolates in one process:
-// - DdsEnsureInit initializes thread memory exactly once process-wide
-//   (calling SetMaxThreads again from a later isolate resets state under
-//   in-flight or subsequent solves; GetDDSInfo can't be used to probe
-//   because it crashes on an uninitialized library).
-// - DdsNextThreadIndex hands out round-robin thread indices, so isolates
-//   created within a window of DDS_SHIM_THREADS of each other never share
-//   an index. Concurrent solves are safe as long as no more than
-//   DDS_SHIM_THREADS isolates are in flight at once.
+//
+// - DdsEnsureInit initializes thread memory exactly once process-wide.
+//   Calling SetMaxThreads again from a later isolate resets state under
+//   in-flight or subsequent solves, and GetDDSInfo can't be used to probe
+//   initialization because it crashes on an uninitialized library.
+// - DdsAcquireThreadIndex / DdsReleaseThreadIndex hand out exclusive
+//   thread indices, bounded by the number of threads DDS actually
+//   configured (SetMaxThreads caps at the core count). Callers must
+//   bracket every solve with acquire/release; when all slots are busy,
+//   acquire returns -1 and the caller should fall back to another solver.
+//   A round-robin dispenser is NOT sufficient: solves finish out of
+//   order, so a slow caller can still hold an index when the counter
+//   wraps around to it.
 
 #include <atomic>
 #include <mutex>
 
 #include "dll.h"
 
-#define DDS_SHIM_THREADS 16
+#define DDS_SHIM_MAX_THREADS 16
+
+static std::atomic<bool> slotBusy[DDS_SHIM_MAX_THREADS];
+static int usableThreads = 0;
 
 extern "C" void DdsEnsureInit() {
   static std::once_flag flag;
-  std::call_once(flag, [] { SetMaxThreads(DDS_SHIM_THREADS); });
+  std::call_once(flag, [] {
+    SetMaxThreads(DDS_SHIM_MAX_THREADS);
+    DDSInfo info;
+    GetDDSInfo(&info);
+    usableThreads = info.noOfThreads;
+    if (usableThreads > DDS_SHIM_MAX_THREADS)
+      usableThreads = DDS_SHIM_MAX_THREADS;
+  });
 }
 
-extern "C" int DdsNextThreadIndex() {
-  static std::atomic<int> counter{0};
-  return counter.fetch_add(1) % DDS_SHIM_THREADS;
+extern "C" int DdsAcquireThreadIndex() {
+  for (int i = 0; i < usableThreads; i++) {
+    bool expected = false;
+    if (slotBusy[i].compare_exchange_strong(expected, true))
+      return i;
+  }
+  return -1;
+}
+
+extern "C" void DdsReleaseThreadIndex(int i) {
+  if (i >= 0 && i < DDS_SHIM_MAX_THREADS)
+    slotBusy[i].store(false);
 }


### PR DESCRIPTION
Adds support for using the [dds](https://github.com/dds-bridge/dds) double-dummy solver, built as a shared library and accessed via Dart FFI. dds is much faster than the existing Dart solver, and verification scripts confirm that they both produce identical results. This allows the bridge AI to always do full solves rather than using heuristics, which produces a gain of +1.46 ± 0.40 IMPs/board.

Currently requires manually pulling the dds source before building, a followup will vendor it into this repo.