### PR TITLE
Update docs and IMP display for bridge

### DIFF
--- a/assets/doc/about.md
+++ b/assets/doc/about.md
@@ -2,7 +2,7 @@ Comments or bug reports: [bnenning@gmail.com](mailto:bnenning@gmail.com)
 
 ## General
 
-In both Hearts and Spades, each player is dealt 13 cards and plays them in a series of "tricks".
+In all games, each player is dealt a hand of cards and plays them in a series of "tricks".
 In each trick, one player leads by playing a card. Each other player then plays a card, in
 clockwise order. You must play a card of the same suit as the card that was led if possible; if not
 you may play any card. Whoever plays the highest card of the suit that was led takes the cards in
@@ -102,6 +102,42 @@ If "Always 13", the match lasts until one player reaches 100 points rather than 
 of rounds.
 - **Score 1 point per trick**: Can be set to have players score 1 point per trick always, never, or
 only when they make their exact bid.
+
+## Bridge
+
+Bridge is a game played by two teams of partners. Your partner is at the top of the screen and the
+opponents are on the sides. A round begins with an "auction", where players bid to set the trump
+suit (or to have no trump suit, "NT") and to say how many tricks they will win with that
+trump. See [here](https://www.acbl.org/learn/) for more detailed rules.
+
+### Bidding
+The bidding system that the AI players use is mostly [Standard American Yellow Card](https://www.bridgebum.com/sayc.php) (SAYC),
+including:
+- 5-card majors with limit raises and Jacoby 2NT
+- Negative doubles
+- Weak opening two-bids, strong 2♣
+- Weak jump overcalls
+- 1NT opening with 15-17 points, Stayman and Jacoby transfers
+- Blackwood and Gerber
+
+You can see the meaning of a bid that a player (including yourself) has made by tapping it in the
+bid table. If you make a bid that's not interpreted how you expected, you can use the "Undo last bid"
+button to rewind the auction to your most recent action.
+
+The AI players do not currently use any conventions for playing cards (e.g. playing high then low to
+indicate an even number of cards).
+
+### Scoring
+Matches are scored as "duplicate teams". Each hand you play is also played separately by AI. The
+difference between your score for the hand and the score that the AI player gets for the same
+hand is converted to [International Match Points](https://en.wikipedia.org/wiki/International_Match_Points) (IMPs). 
+
+For example, suppose you bid and make a contract of 2♠, while in the duplicate hand the player in
+your position also bids 2♠ but fails to make it by one trick. Your score is +110, and your AI
+counterpart's score is -50. The difference is 160 points in your favor, which translates to +4 IMPs.
+
+The length of a match is set in the preferences and can be 1, 4, or 8 hands. The winner of the match
+is determined by the IMPs accumulated over all hands.
 
 ## License
 

--- a/lib/bridge/PLAY_AI.md
+++ b/lib/bridge/PLAY_AI.md
@@ -103,6 +103,7 @@ inference.
 | MCDD dd=7 vs maxtricks MC, seed 43 | 200 | +0.47 +/- 0.33 |
 | MCDD dd=6 vs maxtricks MC, seed 43 | 200 | -0.11 +/- 0.34 |
 | honor-waste guard (final form) vs no guard, seed 11 | 200 | +0.05 +/- 0.20 |
+| honor-waste guard vs no guard with dds backend, seed 37 | 300 | +0.09 +/- 0.07 |
 | full-depth solving vs preroll-only, seed 11 | 200 | **+1.27 +/- 0.30** |
 | full-depth vs preroll-only at app config (2.2s), seed 5 | 60 | +1.03 +/- 0.59 |
 | **final engine vs maxtricks MC, seed 21** | 300 | **+2.07 +/- 0.27** |
@@ -198,7 +199,7 @@ Lesson: suppress only the exact artifact pattern and fall back along the
 measured-equity ranking, not to conventional play; every deferral to the
 heuristic's judgment costs measurable equity.
 
-Re-measured after full-depth solving landed: the guard remains
+Re-measured after full-depth solving landed: the guard remained
 worthwhile — +0.31 +/- 0.18 IMPs/board vs guard-off (200 boards; free
 to mildly positive), while still halving flagged unsupported-honor
 leads (25 -> 12 at 50 sampled deals; into-dummy-honor leads 8 -> 2),
@@ -207,6 +208,21 @@ naturalness refinements: a K/Q that has become the *master* is exempt
 (cashing it is never the artifact), and lead candidates from groups of
 touching honors are represented by the top card (lead A from AKQ, not
 the double-dummy-equivalent Q).
+
+Re-measured again with the native dds backend (universal full-depth
+solves, no budget aborts): the guard is now vestigial where dds is
+active — +0.09 +/- 0.07 IMPs/board with 289 of 300 boards identical,
+and the lead scan produces byte-identical output with the guard on or
+off (12 flags at 50 sampled deals, mostly heuristic-endorsed, zero
+into a higher dummy honor). Each layer of the fix made the previous
+one more redundant: the guard cut the original artifact ~70%,
+full-depth solving cut most of the rest, and dds-everywhere finished
+it — the old noise-decided near-ties are now exact ties, settled by
+the ordinary lowest-card tie-break. The guard is kept as insurance for
+the pure-Dart fallback path (iOS, or any platform where the library
+fails to load), where budget aborts and preroll fallbacks still occur;
+when that path becomes vestigial too, the guard can be deleted with
+it.
 
 ## Full-depth solving (preroll bias)
 

--- a/lib/bridge/PLAY_AI.md
+++ b/lib/bridge/PLAY_AI.md
@@ -107,6 +107,7 @@ inference.
 | full-depth solving vs preroll-only, seed 11 | 200 | **+1.27 +/- 0.30** |
 | full-depth vs preroll-only at app config (2.2s), seed 5 | 60 | +1.03 +/- 0.59 |
 | **final engine vs maxtricks MC, seed 21** | 300 | **+2.07 +/- 0.27** |
+| **final engine with dds backend vs maxtricks MC, seed 41** | 300 | **+3.35 +/- 0.28** |
 
 Two negative results shaped the final design:
 
@@ -273,7 +274,11 @@ preroll-bias tax whenever its node budget forces a fallback, the dds
 side never does — at ~26ms vs ~767ms average per play under a fully
 parallel harness (~10ms vs ~130ms uncontended). The speed headroom is
 the point for mobile: full evaluation quality on slow devices, and an
-order of magnitude less CPU per play.
+order of magnitude less CPU per play. Against the original
+maxtricks-rollout MC baseline, the dds-backed engine measures
+**+3.35 +/- 0.28 IMPs/board** (300 boards, 205-22-73) at ~28ms per
+play — the cumulative gain of the whole project, delivered at roughly
+the compute cost of the AI it replaced.
 
 The delicate part was multi-isolate safety, handled by a shim compiled
 into our libdds build (`cpp/dds_shim.cpp`): DDS thread memory must be

--- a/lib/bridge/bridge.dart
+++ b/lib/bridge/bridge.dart
@@ -820,23 +820,37 @@ class BridgeMatch {
         duplicateRound.contractScoreForPlayer(0));
   }
 
-  // Running IMP total for players 0 and 2, over rounds whose duplicate
-  // replay has finished.
-  int totalImpsForPlayer0() {
+  // IMPs for N/s over rounds whose duplicate replay has finished.
+  List<int> netImpsPerRoundForPlayer0() {
+    final imps = <int>[];
     int total = 0;
     for (int i = 0;
         i < previousRounds.length && i < previousDuplicateRounds.length;
         i++) {
       if (previousDuplicateRounds[i].isOver()) {
-        total += impsForRounds(previousRounds[i], previousDuplicateRounds[i]);
+        imps.add(impsForRounds(previousRounds[i], previousDuplicateRounds[i]));
       }
     }
     if (!_isCurrentRoundArchived &&
         currentRound.isOver() &&
         duplicateRound.isOver()) {
-      total += impsForRounds(currentRound, duplicateRound);
+      imps.add(impsForRounds(currentRound, duplicateRound));
     }
-    return total;
+    return imps;
+  }
+
+  int netImpsForPlayer0() {
+    return netImpsPerRoundForPlayer0().fold(0, (a, b) => a + b);
+  }
+
+  // Negative IMPs for N/S become positive for E/W,
+  // e.g. [3, 0, 2, -4] => [5, 4]
+  List<int> totalImpsPerTeam() {
+    final netImps = netImpsPerRoundForPlayer0();
+    return [
+      netImps.where((imps) => imps > 0).fold(0, (a, b) => a + b),
+      netImps.where((imps) => imps < 0).fold(0, (a, b) => a - b),
+    ];
   }
 
   // Returns 0 for N/S win, 1 for E/W, null if tied or if the match isn't over.
@@ -844,7 +858,7 @@ class BridgeMatch {
     if (!isMatchOver()) {
       return null;
     }
-    int imps = totalImpsForPlayer0();
+    int imps = netImpsForPlayer0();
     if (imps == 0) {
       return null;
     }

--- a/lib/bridge/bridge_stats.dart
+++ b/lib/bridge/bridge_stats.dart
@@ -183,7 +183,7 @@ class BridgeStats {
 
   /// Updates stats for a finished match (all duplicate replays done).
   BridgeStats updateFromMatch(BridgeMatch match) {
-    final imps = match.totalImpsForPlayer0();
+    final imps = match.netImpsForPlayer0();
     return copyWith(
       numMatches: numMatches + 1,
       numMatchesWon: numMatchesWon + (imps > 0 ? 1 : 0),

--- a/lib/bridge_ui.dart
+++ b/lib/bridge_ui.dart
@@ -922,7 +922,8 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
                 identical(_ddResultRound, round) ? _ddDeclarerTricks : null,
             onContinue: () => setState(_startRound),
             onMainMenu: _showMainMenuAfterMatch,
-            onReplayDuplicateRound: _runDuplicateRound,
+            // Uncomment to show button to replay duplicate round.
+            // onReplayDuplicateRound: _runDuplicateRound,
           ),
         PlayerMoods(layout: layout, moods: playerMoods, durationMillis: 5000),
         if (_shouldShowScoreOverlay()) _scoreOverlay(),
@@ -1310,6 +1311,7 @@ class EndOfRoundDialog extends StatelessWidget {
     int myScore = round.contractScoreForPlayer(0);
     int dupScore = duplicateRound.contractScoreForPlayer(0);
     int scoreDiff = myScore - dupScore;
+    final [nsImps, ewImps] = match.totalImpsPerTeam();
 
     return [
       makeRow([
@@ -1337,16 +1339,16 @@ class EndOfRoundDialog extends StatelessWidget {
           child: const Text("Replay duplicate round"),
         )),
       ]),
-      makeRow([
+      if (match.numRounds > 1) makeRow([
         Padding(
             padding: const EdgeInsets.only(top: 10),
-            child: Text("Total IMPs: ${plusPrefixIfPositive(match.totalImpsForPlayer0())}",
+            child: Text("Match IMPs: $nsImps – $ewImps",
                 style: const TextStyle(fontSize: 16))),
       ]),
       if (match.isMatchOver()) makeRow([
         Padding(
             padding: const EdgeInsets.only(top: 10),
-            child: Text(matchResultDescription(match.totalImpsForPlayer0()),
+            child: Text(matchResultDescription(match.netImpsForPlayer0()),
                 style: const TextStyle(
                     fontSize: 18, fontWeight: FontWeight.bold))),
       ]),

--- a/lib/cards/card.dart
+++ b/lib/cards/card.dart
@@ -33,15 +33,19 @@ enum Suit {
   static Suit fromChar(String ch) {
     switch (ch) {
       case 'C':
+      case 'c':
       case '♣':
         return clubs;
       case 'D':
+      case 'd':
       case '♦':
         return diamonds;
       case 'H':
+      case 'h':
       case '♥':
         return hearts;
       case 'S':
+      case 's':
       case '♠':
         return spades;
       default:

--- a/test/bridge/bridge_test.dart
+++ b/test/bridge/bridge_test.dart
@@ -467,17 +467,17 @@ void main() {
 
       bidAndPlayOutRound(match.currentRound, rng);
       // Duplicate round hasn't finished; no IMPs yet.
-      expect(match.totalImpsForPlayer0(), 0);
+      expect(match.netImpsForPlayer0(), 0);
       bidAndPlayOutRound(match.duplicateRound, rng);
 
       final expectedImps = impsForScoreDifference(
           match.currentRound.contractScoreForPlayer(0) -
               match.duplicateRound.contractScoreForPlayer(0));
-      expect(match.totalImpsForPlayer0(), expectedImps);
+      expect(match.netImpsForPlayer0(), expectedImps);
 
       // Total persists after the round is archived and a new one dealt.
       match.finishRound();
-      expect(match.totalImpsForPlayer0(), expectedImps);
+      expect(match.netImpsForPlayer0(), expectedImps);
       expect(match.currentRound.isOver(), false);
 
       // A second finished round adds its IMPs to the total.
@@ -486,7 +486,7 @@ void main() {
       final round2Imps = impsForScoreDifference(
           match.currentRound.contractScoreForPlayer(0) -
               match.duplicateRound.contractScoreForPlayer(0));
-      expect(match.totalImpsForPlayer0(), expectedImps + round2Imps);
+      expect(match.netImpsForPlayer0(), expectedImps + round2Imps);
     });
 
     test("Serialization preserves rounds and IMP total", () {
@@ -507,7 +507,7 @@ void main() {
       expect(restored.numCompletedRounds, 2);
       expect(restored.currentRound.vulnerability, Vulnerability.nsOnly);
       expect(restored.duplicateRound.vulnerability, Vulnerability.nsOnly);
-      expect(restored.totalImpsForPlayer0(), match.totalImpsForPlayer0());
+      expect(restored.netImpsForPlayer0(), match.netImpsForPlayer0());
     });
 
     test("Contract vulnerability follows round vulnerability", () {
@@ -537,7 +537,7 @@ void main() {
       expect(restored.numRounds, 4);
       expect(restored.previousDuplicateRounds, isEmpty);
       expect(restored.duplicateRound.isOver(), false);
-      expect(restored.totalImpsForPlayer0(), 0);
+      expect(restored.netImpsForPlayer0(), 0);
     });
   });
 }


### PR DESCRIPTION
Also some notes by Claude on the current state of the heuristic to avoid playing unsupported high honors (no longer needed with dds solver, but useful if dds isn't loaded).