### PR TITLE
Add "Show details" dialog for reviewing the duplicate bridge round 

### DIFF
--- a/lib/bridge_ui.dart
+++ b/lib/bridge_ui.dart
@@ -1543,7 +1543,7 @@ class _RoundDetailsDialogState extends State<RoundDetailsDialog> {
             borderRadius: BorderRadius.circular(5),
           ),
           child: Image.asset("assets/cards/solid/${card.toString()}.webp",
-              height: 64));
+              height: 72));
     }
 
     // Arrow in the center of the cross pointing at the trick leader's card.
@@ -1552,14 +1552,21 @@ class _RoundDetailsDialogState extends State<RoundDetailsDialog> {
         child: const Icon(Icons.arrow_upward, size: 24, color: Colors.black54));
 
     // Cross layout matching the table: N top, W left, E right, S bottom.
+    // Arrow in the center points to the trick leader.
+    final trickCards = Row(mainAxisSize: MainAxisSize.min,
+      children: [
+        Center(child: seatCard(1)),
+        Column(children: [
+          seatCard(2),
+          SizedBox(height: 32, child: Center(child: leadArrow)),
+          seatCard(0),
+        ]),
+        Center(child: seatCard(3)),
+      ],
+    );
+
     return Column(mainAxisSize: MainAxisSize.min, children: [
-      seatCard(2),
-      Row(mainAxisSize: MainAxisSize.min, children: [
-        seatCard(1),
-        SizedBox(width: 56, child: Center(child: leadArrow)),
-        seatCard(3),
-      ]),
-      seatCard(0),
+      trickCards,
       Row(mainAxisSize: MainAxisSize.min, children: [
         IconButton(
           icon: const Icon(Icons.chevron_left),

--- a/lib/bridge_ui.dart
+++ b/lib/bridge_ui.dart
@@ -1000,10 +1000,9 @@ class _BidHistoryTableState extends State<BidHistoryTable> {
           },
           child: Container(
             color: isExplainingBid ? Colors.white : Colors.transparent,
-            child: Text(
+            child: Padding(padding: const EdgeInsets.symmetric(horizontal: 8), child: Text(
               bidHistory[bidIndex].action.symbolString(),
-              style: TextStyle(fontWeight: isExplainingBid ? FontWeight.bold : FontWeight.normal),
-              textAlign: TextAlign.center)),
+              textAlign: TextAlign.center))),
       );
     }
 

--- a/lib/bridge_ui.dart
+++ b/lib/bridge_ui.dart
@@ -1546,11 +1546,6 @@ class _RoundDetailsDialogState extends State<RoundDetailsDialog> {
               height: 72));
     }
 
-    // Arrow in the center of the cross pointing at the trick leader's card.
-    final leadArrow = RotatedBox(
-        quarterTurns: (trick.leader + 2) % 4,
-        child: const Icon(Icons.arrow_upward, size: 24, color: Colors.black54));
-
     // Cross layout matching the table: N top, W left, E right, S bottom.
     // Arrow in the center points to the trick leader.
     final trickCards = Row(mainAxisSize: MainAxisSize.min,
@@ -1558,7 +1553,9 @@ class _RoundDetailsDialogState extends State<RoundDetailsDialog> {
         Center(child: seatCard(1)),
         Column(children: [
           seatCard(2),
-          SizedBox(height: 32, child: Center(child: leadArrow)),
+          SizedBox(height: 32, child: Center(child: RotatedBox(
+              quarterTurns: (trick.leader + 2) % 4,
+              child: const Icon(Icons.arrow_upward, size: 24, color: Colors.black54)))),
           seatCard(0),
         ]),
         Center(child: seatCard(3)),

--- a/lib/bridge_ui.dart
+++ b/lib/bridge_ui.dart
@@ -110,8 +110,8 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
   // Flag to keep the bidding dialog visible after bidding is completed, until
   // the player starts the round.
   bool showPostBidDialog = false;
-  // Replaces the end-of-round dialog with the duplicate round details dialog.
-  bool showDuplicateRoundDetails = false;
+  // Replaces the end-of-round dialog with the round details dialog.
+  bool showRoundDetails = false;
   var aiMode = AiMode.humanPlayer0;
   int currentBidder = 0;
   Map<int, Mood> playerMoods = {};
@@ -183,7 +183,7 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
   void _startRound() {
     _clearMoods();
     isClaimingRemainingTricks = false;
-    showDuplicateRoundDetails = false;
+    showRoundDetails = false;
     _statsUpdatePending = false;
     if (round.isOver()) {
       match.finishRound();
@@ -916,7 +916,7 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
           ),
         if (_shouldShowClaimTricksDialog())
           ClaimRemainingTricksDialog(onOk: _handleClaimTricksDialogOk),
-        if (_shouldShowEndOfRoundDialog() && !showDuplicateRoundDetails)
+        if (_shouldShowEndOfRoundDialog() && !showRoundDetails)
           EndOfRoundDialog(
             layout: layout,
             match: match,
@@ -928,14 +928,15 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
             // Uncomment to show button to replay duplicate round.
             // onReplayDuplicateRound: _runDuplicateRound,
             onShowDetails: duplicateRound.isOver()
-                ? () => setState(() => showDuplicateRoundDetails = true)
+                ? () => setState(() => showRoundDetails = true)
                 : null,
           ),
-        if (_shouldShowEndOfRoundDialog() && showDuplicateRoundDetails)
-          DuplicateRoundDetailsDialog(
+        if (_shouldShowEndOfRoundDialog() && showRoundDetails)
+          RoundDetailsDialog(
             layout: layout,
-            round: duplicateRound,
-            onClose: () => setState(() => showDuplicateRoundDetails = false),
+            round: round,
+            duplicateRound: duplicateRound,
+            onClose: () => setState(() => showRoundDetails = false),
           ),
         PlayerMoods(layout: layout, moods: playerMoods, durationMillis: 5000),
         if (_shouldShowScoreOverlay()) _scoreOverlay(),
@@ -1481,30 +1482,34 @@ class EndOfRoundDialog extends StatelessWidget {
   }
 }
 
-/// Shows what happened in the duplicate round, with tabs for the auction
-/// (as a BidHistoryTable with seat letter headers) and the play (one trick
-/// at a time with the winning card highlighted).
-class DuplicateRoundDetailsDialog extends StatefulWidget {
+/// Shows what happened in the player's round or the duplicate round, with
+/// tabs for the auction (as a BidHistoryTable with seat letter headers) and
+/// the play (one trick at a time with the winning card highlighted).
+class RoundDetailsDialog extends StatefulWidget {
   final Layout layout;
   final BridgeRound round;
+  final BridgeRound duplicateRound;
   final Function() onClose;
 
-  const DuplicateRoundDetailsDialog({
+  const RoundDetailsDialog({
     super.key,
     required this.layout,
     required this.round,
+    required this.duplicateRound,
     required this.onClose,
   });
 
   @override
-  State<DuplicateRoundDetailsDialog> createState() =>
-      _DuplicateRoundDetailsDialogState();
+  State<RoundDetailsDialog> createState() => _RoundDetailsDialogState();
 }
 
-class _DuplicateRoundDetailsDialogState
-    extends State<DuplicateRoundDetailsDialog> {
+class _RoundDetailsDialogState extends State<RoundDetailsDialog> {
+  bool showDuplicate = false;
   int selectedTabIndex = 0;
   int trickIndex = 0;
+
+  BridgeRound get selectedRound =>
+      showDuplicate ? widget.duplicateRound : widget.round;
 
   Widget biddingTab() {
     Widget headerCell(String msg) => paddingAll(
@@ -1513,13 +1518,13 @@ class _DuplicateRoundDetailsDialogState
             textAlign: TextAlign.center,
             style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold)));
 
-    return BidHistoryTable(round: widget.round, headerCells: [
+    return BidHistoryTable(round: selectedRound, headerCells: [
       for (int p = 0; p < 4; p++) headerCell("SWNE"[p]),
     ]);
   }
 
   Widget playTab() {
-    final tricks = widget.round.previousTricks;
+    final tricks = selectedRound.previousTricks;
     if (tricks.isEmpty) {
       return paddingAll(20, const Text("No cards were played."));
     }
@@ -1585,21 +1590,48 @@ class _DuplicateRoundDetailsDialogState
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     paddingAll(
-                        10,
-                        ToggleButtons(
-                          isSelected: [
-                            selectedTabIndex == 0,
-                            selectedTabIndex == 1
+                        8,
+                        SegmentedButton<bool>(
+                          segments: const [
+                            ButtonSegment(
+                                value: false,
+                                label: Text("Your round",
+                                    style: TextStyle(fontSize: 12))),
+                            ButtonSegment(
+                                value: true,
+                                label: Text("Duplicate",
+                                    style: TextStyle(fontSize: 12))),
                           ],
-                          onPressed: (index) =>
-                              setState(() => selectedTabIndex = index),
-                          borderRadius: BorderRadius.circular(5),
-                          constraints: const BoxConstraints(
-                              minHeight: 30, minWidth: 70),
-                          children: const [
-                            Text("Bidding", style: TextStyle(fontSize: 12)),
-                            Text("Play", style: TextStyle(fontSize: 12)),
+                          showSelectedIcon: false,
+                          style: const ButtonStyle(
+                              visualDensity: VisualDensity.compact),
+                          selected: {showDuplicate},
+                          onSelectionChanged: (selection) => setState(() {
+                            showDuplicate = selection.first;
+                            trickIndex = 0;
+                          }),
+                        )),
+                    Text(roundResultDescription(selectedRound),
+                        style: const TextStyle(fontSize: 14)),
+                    paddingAll(
+                        8,
+                        SegmentedButton<int>(
+                          segments: const [
+                            ButtonSegment(
+                                value: 0,
+                                label: Text("Bidding",
+                                    style: TextStyle(fontSize: 12))),
+                            ButtonSegment(
+                                value: 1,
+                                label: Text("Play",
+                                    style: TextStyle(fontSize: 12))),
                           ],
+                          showSelectedIcon: false,
+                          style: const ButtonStyle(
+                              visualDensity: VisualDensity.compact),
+                          selected: {selectedTabIndex},
+                          onSelectionChanged: (selection) => setState(
+                              () => selectedTabIndex = selection.first),
                         )),
                     if (selectedTabIndex == 0) biddingTab(),
                     if (selectedTabIndex == 1) playTab(),

--- a/lib/bridge_ui.dart
+++ b/lib/bridge_ui.dart
@@ -1609,7 +1609,7 @@ class _RoundDetailsDialogState extends State<RoundDetailsDialog> {
                           selected: {showDuplicate},
                           onSelectionChanged: (selection) => setState(() {
                             showDuplicate = selection.first;
-                            trickIndex = 0;
+                            // Intentionally keep the trick index where it was.
                           }),
                         )),
                     Text(roundResultDescription(selectedRound),

--- a/lib/bridge_ui.dart
+++ b/lib/bridge_ui.dart
@@ -558,6 +558,7 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
     setState(() {
       isClaimingRemainingTricks = false;
     });
+    widget.saveMatchFn(match);
     _updateMoodsAfterTrick();
     _playSoundsForMoods();
     // Safety net only: the replay normally started at the round's

--- a/lib/bridge_ui.dart
+++ b/lib/bridge_ui.dart
@@ -110,6 +110,8 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
   // Flag to keep the bidding dialog visible after bidding is completed, until
   // the player starts the round.
   bool showPostBidDialog = false;
+  // Replaces the end-of-round dialog with the duplicate round details dialog.
+  bool showDuplicateRoundDetails = false;
   var aiMode = AiMode.humanPlayer0;
   int currentBidder = 0;
   Map<int, Mood> playerMoods = {};
@@ -181,6 +183,7 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
   void _startRound() {
     _clearMoods();
     isClaimingRemainingTricks = false;
+    showDuplicateRoundDetails = false;
     _statsUpdatePending = false;
     if (round.isOver()) {
       match.finishRound();
@@ -913,7 +916,7 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
           ),
         if (_shouldShowClaimTricksDialog())
           ClaimRemainingTricksDialog(onOk: _handleClaimTricksDialogOk),
-        if (_shouldShowEndOfRoundDialog())
+        if (_shouldShowEndOfRoundDialog() && !showDuplicateRoundDetails)
           EndOfRoundDialog(
             layout: layout,
             match: match,
@@ -924,6 +927,15 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
             onMainMenu: _showMainMenuAfterMatch,
             // Uncomment to show button to replay duplicate round.
             // onReplayDuplicateRound: _runDuplicateRound,
+            onShowDetails: duplicateRound.isOver()
+                ? () => setState(() => showDuplicateRoundDetails = true)
+                : null,
+          ),
+        if (_shouldShowEndOfRoundDialog() && showDuplicateRoundDetails)
+          DuplicateRoundDetailsDialog(
+            layout: layout,
+            round: duplicateRound,
+            onClose: () => setState(() => showDuplicateRoundDetails = false),
           ),
         PlayerMoods(layout: layout, moods: playerMoods, durationMillis: 5000),
         if (_shouldShowScoreOverlay()) _scoreOverlay(),
@@ -935,60 +947,34 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
 
 const dialogBackgroundColor = Color.fromARGB(0x80, 0xd8, 0xd8, 0xd8);
 
-class BidDialog extends StatefulWidget {
-  final Layout layout;
+/// The auction as a table, one column per seat, with tap-to-explain of any
+/// call's SAYC meaning. Used while bidding (BidDialog, with "You"/cat image
+/// headers) and when reviewing a finished round (with seat letter headers).
+class BidHistoryTable extends StatefulWidget {
   final BridgeRound round;
-  final void Function(PlayerBid) onBid;
-  final void Function() onResetBids;
-  final void Function() onConfirmContract;
-  final List<int> catImageIndices;
+  // Exactly four header cells, in player index order.
+  final List<Widget> headerCells;
 
-  const BidDialog({
+  const BidHistoryTable({
     super.key,
-    required this.layout,
     required this.round,
-    required this.onBid,
-    required this.onResetBids,
-    required this.onConfirmContract,
-    required this.catImageIndices,
+    required this.headerCells,
   });
 
   @override
-  State<BidDialog> createState() => _BidDialogState();
+  State<BidHistoryTable> createState() => _BidHistoryTableState();
 }
 
-class _BidDialogState extends State<BidDialog> {
-  ContractBid contractBid = ContractBid(1, Suit.clubs);
+class _BidHistoryTableState extends State<BidHistoryTable> {
   int? explainBidRow;
   int explainBidColumn = 0;
-  String bidExplanation = "";
 
   @override
   Widget build(BuildContext context) {
-    const adjustBidTextStyle = TextStyle(fontSize: 18, height: 0);
-    const headerFontSize = 14.0;
-    const cellPad = 4.0;
-    const rowPadding = 15.0;
-
-    Widget headerCell(String msg) => paddingAll(
-        cellPad,
-        Text(msg,
-            textAlign: TextAlign.right,
-            style: const TextStyle(
-                fontSize: headerFontSize, fontWeight: FontWeight.bold)));
-
-    Widget catImageCell(int imageIndex) {
-      const imageHeight = headerFontSize * 1.3;
-      const padding = headerFontSize * 0.85;
-      return paddingHorizontal(padding,
-          Image.asset(catImageForIndex(imageIndex), height: imageHeight));
-    }
-
     final bidHistory = widget.round.bidHistory;
     final dealer = widget.round.dealer;
     final isBiddingOver = widget.round.contract != null || widget.round.isPassedOut();
     final numberOfBidRows = ((dealer + bidHistory.length + (isBiddingOver ? 0 : 1)) / 4).ceil();
-    final hasHumanBid = bidHistory.any((b) => b.player == 0);
 
     Widget bidCell({required int rowIndex, required int playerIndex}) {
       int bidIndex = 4 * rowIndex + playerIndex - dealer;
@@ -1037,6 +1023,81 @@ class _BidDialogState extends State<BidDialog> {
         )),
       ));
     }
+
+    return Column(mainAxisSize: MainAxisSize.min, children: [
+      paddingAll(
+          10,
+          Table(
+            defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+            defaultColumnWidth: const IntrinsicColumnWidth(),
+            children: [
+              TableRow(children: widget.headerCells),
+              ...[
+                for (var row = 0; row < numberOfBidRows; row += 1)
+                  TableRow(children: [
+                    bidCell(rowIndex: row, playerIndex: 0),
+                    bidCell(rowIndex: row, playerIndex: 1),
+                    bidCell(rowIndex: row, playerIndex: 2),
+                    bidCell(rowIndex: row, playerIndex: 3),
+                  ])
+              ]
+            ],
+          )),
+      if (explainBidRow != null) bidExplanation(),
+    ]);
+  }
+}
+
+class BidDialog extends StatefulWidget {
+  final Layout layout;
+  final BridgeRound round;
+  final void Function(PlayerBid) onBid;
+  final void Function() onResetBids;
+  final void Function() onConfirmContract;
+  final List<int> catImageIndices;
+
+  const BidDialog({
+    super.key,
+    required this.layout,
+    required this.round,
+    required this.onBid,
+    required this.onResetBids,
+    required this.onConfirmContract,
+    required this.catImageIndices,
+  });
+
+  @override
+  State<BidDialog> createState() => _BidDialogState();
+}
+
+class _BidDialogState extends State<BidDialog> {
+  ContractBid contractBid = ContractBid(1, Suit.clubs);
+
+  @override
+  Widget build(BuildContext context) {
+    const adjustBidTextStyle = TextStyle(fontSize: 18, height: 0);
+    const headerFontSize = 14.0;
+    const cellPad = 4.0;
+    const rowPadding = 15.0;
+
+    Widget headerCell(String msg) => paddingAll(
+        cellPad,
+        Text(msg,
+            textAlign: TextAlign.right,
+            style: const TextStyle(
+                fontSize: headerFontSize, fontWeight: FontWeight.bold)));
+
+    Widget catImageCell(int imageIndex) {
+      const imageHeight = headerFontSize * 1.3;
+      const padding = headerFontSize * 0.85;
+      return paddingHorizontal(padding,
+          Image.asset(catImageForIndex(imageIndex), height: imageHeight));
+    }
+
+    final bidHistory = widget.round.bidHistory;
+    final dealer = widget.round.dealer;
+    final isBiddingOver = widget.round.contract != null || widget.round.isPassedOut();
+    final hasHumanBid = bidHistory.any((b) => b.player == 0);
 
     bool canDecrementBid() {
       return contractBid.count > 1;
@@ -1117,16 +1178,6 @@ class _BidDialogState extends State<BidDialog> {
       });
     }
 
-    final bidRows = <TableRow>[];
-    for (var row = 0; row < numberOfBidRows; row++) {
-      bidRows.add(TableRow(children: [
-        bidCell(rowIndex: row, playerIndex: 0),
-        bidCell(rowIndex: row, playerIndex: 1),
-        bidCell(rowIndex: row, playerIndex: 2),
-        bidCell(rowIndex: row, playerIndex: 3),
-      ]));
-    }
-
     String contractMessage() {
       if (widget.round.contract == null) {
         return "The hand is passed out.";
@@ -1161,34 +1212,12 @@ class _BidDialogState extends State<BidDialog> {
                           child: Text(
                               "Vulnerable: ${vulnerabilityDescription(widget.round.vulnerability)}",
                               style: const TextStyle(fontSize: 12))),
-                      paddingAll(
-                          10,
-                          Table(
-                            defaultVerticalAlignment:
-                                TableCellVerticalAlignment.middle,
-                            defaultColumnWidth: const IntrinsicColumnWidth(),
-                            children: [
-                              TableRow(children: [
-                                paddingHorizontal(cellPad, headerCell("You")),
-                                catImageCell(widget.catImageIndices[1]),
-                                catImageCell(widget.catImageIndices[2]),
-                                catImageCell(widget.catImageIndices[3]),
-                              ]),
-                              ...[
-                                for (var row = 0;
-                                    row < numberOfBidRows;
-                                    row += 1)
-                                  TableRow(children: [
-                                    bidCell(rowIndex: row, playerIndex: 0),
-                                    bidCell(rowIndex: row, playerIndex: 1),
-                                    bidCell(rowIndex: row, playerIndex: 2),
-                                    bidCell(rowIndex: row, playerIndex: 3),
-                                  ])
-                              ]
-                            ],
-                          )
-                      ),
-                      if (explainBidRow != null) bidExplanation(),
+                      BidHistoryTable(round: widget.round, headerCells: [
+                        paddingHorizontal(cellPad, headerCell("You")),
+                        catImageCell(widget.catImageIndices[1]),
+                        catImageCell(widget.catImageIndices[2]),
+                        catImageCell(widget.catImageIndices[3]),
+                      ]),
 
                       if (!isBiddingOver) ...[
                         Row(
@@ -1286,6 +1315,8 @@ class EndOfRoundDialog extends StatelessWidget {
   final Function() onMainMenu;
   // For testing to see how the AI plays the hand over multiple runs.
   final Function()? onReplayDuplicateRound;
+  // Switches to the duplicate round details dialog.
+  final Function()? onShowDetails;
 
   const EndOfRoundDialog({
     super.key,
@@ -1296,6 +1327,7 @@ class EndOfRoundDialog extends StatelessWidget {
     required this.onContinue,
     required this.onMainMenu,
     this.onReplayDuplicateRound,
+    this.onShowDetails,
   });
 
   Row makeRow(List<Widget> children) {
@@ -1330,6 +1362,12 @@ class EndOfRoundDialog extends StatelessWidget {
         paddingAll(
             0,
             Text("IMPs: ${plusPrefixIfPositive(impsForScoreDifference(scoreDiff))}")
+        ),
+      ]),
+      if (onShowDetails != null) makeRow([
+        TextButton(
+          onPressed: onShowDetails,
+          child: const Text("Show details", style: TextStyle(fontSize: 12)),
         ),
       ]),
       if (onReplayDuplicateRound != null) makeRow([
@@ -1441,6 +1479,140 @@ class EndOfRoundDialog extends StatelessWidget {
       builder: (context, val, child) =>
           Opacity(opacity: val.clamp(0.0, 1.0), child: child),
     );
+  }
+}
+
+/// Shows what happened in the duplicate round, with tabs for the auction
+/// (as a BidHistoryTable with seat letter headers) and the play (one trick
+/// at a time with the winning card highlighted).
+class DuplicateRoundDetailsDialog extends StatefulWidget {
+  final Layout layout;
+  final BridgeRound round;
+  final Function() onClose;
+
+  const DuplicateRoundDetailsDialog({
+    super.key,
+    required this.layout,
+    required this.round,
+    required this.onClose,
+  });
+
+  @override
+  State<DuplicateRoundDetailsDialog> createState() =>
+      _DuplicateRoundDetailsDialogState();
+}
+
+class _DuplicateRoundDetailsDialogState
+    extends State<DuplicateRoundDetailsDialog> {
+  int selectedTabIndex = 0;
+  int trickIndex = 0;
+
+  Widget biddingTab() {
+    Widget headerCell(String msg) => paddingAll(
+        4,
+        Text(msg,
+            textAlign: TextAlign.center,
+            style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold)));
+
+    return BidHistoryTable(round: widget.round, headerCells: [
+      for (int p = 0; p < 4; p++) headerCell("SWNE"[p]),
+    ]);
+  }
+
+  Widget playTab() {
+    final tricks = widget.round.previousTricks;
+    if (tricks.isEmpty) {
+      return paddingAll(20, const Text("No cards were played."));
+    }
+    final trick = tricks[trickIndex];
+
+    Widget seatCard(int playerIndex) {
+      final cardIndex = (playerIndex - trick.leader) % 4;
+      final card = trick.cards[cardIndex];
+      final isWinner = playerIndex == trick.winner;
+      return Column(mainAxisSize: MainAxisSize.min, children: [
+        Text("SWNE"[playerIndex],
+            style:
+                const TextStyle(fontSize: 12, fontWeight: FontWeight.bold)),
+        const SizedBox(height: 2),
+        Container(
+            decoration: BoxDecoration(
+              border: Border.all(
+                  color: isWinner ? Colors.amber : Colors.transparent,
+                  width: 2.5),
+              borderRadius: BorderRadius.circular(5),
+            ),
+            child: Image.asset("assets/cards/solid/${card.toString()}.webp",
+                height: 64)),
+      ]);
+    }
+
+    // Cross layout matching the table: N top, W left, E right, S bottom.
+    return Column(mainAxisSize: MainAxisSize.min, children: [
+      seatCard(2),
+      Row(mainAxisSize: MainAxisSize.min, children: [
+        seatCard(1),
+        const SizedBox(width: 56),
+        seatCard(3),
+      ]),
+      seatCard(0),
+      Row(mainAxisSize: MainAxisSize.min, children: [
+        IconButton(
+          icon: const Icon(Icons.chevron_left),
+          onPressed: trickIndex > 0
+              ? () => setState(() => trickIndex -= 1)
+              : null,
+        ),
+        Text("Trick ${trickIndex + 1} of ${tricks.length}",
+            style: const TextStyle(fontSize: 12)),
+        IconButton(
+          icon: const Icon(Icons.chevron_right),
+          onPressed: trickIndex < tricks.length - 1
+              ? () => setState(() => trickIndex += 1)
+              : null,
+        ),
+      ]),
+    ]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+        child: Transform.scale(
+            scale: widget.layout.dialogScale(),
+            child: Dialog(
+                insetPadding: EdgeInsets.zero,
+                backgroundColor: dialogBackgroundColor,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    paddingAll(
+                        10,
+                        ToggleButtons(
+                          isSelected: [
+                            selectedTabIndex == 0,
+                            selectedTabIndex == 1
+                          ],
+                          onPressed: (index) =>
+                              setState(() => selectedTabIndex = index),
+                          borderRadius: BorderRadius.circular(5),
+                          constraints: const BoxConstraints(
+                              minHeight: 30, minWidth: 70),
+                          children: const [
+                            Text("Bidding", style: TextStyle(fontSize: 12)),
+                            Text("Play", style: TextStyle(fontSize: 12)),
+                          ],
+                        )),
+                    if (selectedTabIndex == 0) biddingTab(),
+                    if (selectedTabIndex == 1) playTab(),
+                    paddingAll(
+                        10,
+                        ElevatedButton(
+                          onPressed: widget.onClose,
+                          child: const Text("Back"),
+                        )),
+                  ],
+                ))));
   }
 }
 

--- a/lib/bridge_ui.dart
+++ b/lib/bridge_ui.dart
@@ -1530,29 +1530,28 @@ class _DuplicateRoundDetailsDialogState
       final cardIndex = (playerIndex - trick.leader) % 4;
       final card = trick.cards[cardIndex];
       final isWinner = playerIndex == trick.winner;
-      return Column(mainAxisSize: MainAxisSize.min, children: [
-        Text("SWNE"[playerIndex],
-            style:
-                const TextStyle(fontSize: 12, fontWeight: FontWeight.bold)),
-        const SizedBox(height: 2),
-        Container(
-            decoration: BoxDecoration(
-              border: Border.all(
-                  color: isWinner ? Colors.amber : Colors.transparent,
-                  width: 2.5),
-              borderRadius: BorderRadius.circular(5),
-            ),
-            child: Image.asset("assets/cards/solid/${card.toString()}.webp",
-                height: 64)),
-      ]);
+      return Container(
+          decoration: BoxDecoration(
+            border: Border.all(
+                color: isWinner ? Colors.amber : Colors.transparent,
+                width: 2.5),
+            borderRadius: BorderRadius.circular(5),
+          ),
+          child: Image.asset("assets/cards/solid/${card.toString()}.webp",
+              height: 64));
     }
+
+    // Arrow in the center of the cross pointing at the trick leader's card.
+    final leadArrow = RotatedBox(
+        quarterTurns: (trick.leader + 2) % 4,
+        child: const Icon(Icons.arrow_upward, size: 24, color: Colors.black54));
 
     // Cross layout matching the table: N top, W left, E right, S bottom.
     return Column(mainAxisSize: MainAxisSize.min, children: [
       seatCard(2),
       Row(mainAxisSize: MainAxisSize.min, children: [
         seatCard(1),
-        const SizedBox(width: 56),
+        SizedBox(width: 56, child: Center(child: leadArrow)),
         seatCard(3),
       ]),
       seatCard(0),

--- a/lib/hearts_ui.dart
+++ b/lib/hearts_ui.dart
@@ -281,6 +281,7 @@ class _HeartsMatchState extends State<HeartsMatchDisplay> {
     setState(() {
       isClaimingRemainingTricks = false;
     });
+    widget.saveMatchFn(match);
     _updateMoodsAfterTrick();
     _playSoundsForMoods();
   }

--- a/lib/ohhell_ui.dart
+++ b/lib/ohhell_ui.dart
@@ -294,6 +294,7 @@ class OhHellMatchState extends State<OhHellMatchDisplay> {
     setState(() {
       isClaimingRemainingTricks = false;
     });
+    widget.saveMatchFn(match);
     _updateMoodsAfterTrick();
     _playSoundsForMoods();
   }

--- a/lib/spades_ui.dart
+++ b/lib/spades_ui.dart
@@ -304,6 +304,7 @@ class _SpadesMatchState extends State<SpadesMatchDisplay> {
     setState(() {
       isClaimingRemainingTricks = false;
     });
+    widget.saveMatchFn(match);
     _updateMoodsAfterTrick();
     _playSoundsForMoods();
   }

--- a/test/bridge_ui_widget_test.dart
+++ b/test/bridge_ui_widget_test.dart
@@ -22,19 +22,36 @@ BridgeRound playedOutRound(Random rng) {
   return round;
 }
 
+BridgeRound passedOutRound(Random rng) {
+  final round = BridgeMatch(rng).currentRound;
+  for (int i = 0; i < 4; i++) {
+    round.addBid(PlayerBid(round.currentBidder(), BidAction.pass()));
+  }
+  return round;
+}
+
+// shortestSide of 350 gives dialogScale() of 1.0, so the dialog fits the
+// test surface and its controls are tappable.
 Layout testLayout() => Layout()
-  ..displaySize = const Size(800, 600)
-  ..playerHeight = 75
+  ..displaySize = const Size(350, 350)
+  ..playerHeight = 44
   ..padding = EdgeInsets.zero;
 
-Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+Widget wrapDialog(BridgeRound round, BridgeRound duplicateRound,
+        {Function()? onClose}) =>
+    MaterialApp(
+        home: Scaffold(
+            body: RoundDetailsDialog(
+                layout: testLayout(),
+                round: round,
+                duplicateRound: duplicateRound,
+                onClose: onClose ?? () {})));
 
 void main() {
   testWidgets("details dialog shows bidding table with seat letters",
       (tester) async {
     final round = playedOutRound(Random(17));
-    await tester.pumpWidget(wrap(DuplicateRoundDetailsDialog(
-        layout: testLayout(), round: round, onClose: () {})));
+    await tester.pumpWidget(wrapDialog(round, passedOutRound(Random(17))));
 
     for (final seat in ["S", "W", "N", "E"]) {
       expect(find.text(seat), findsOneWidget);
@@ -43,13 +60,14 @@ void main() {
     expect(find.text(BidAction.contract(1, Suit.clubs).symbolString()),
         findsOneWidget);
     expect(find.text(BidAction.pass().symbolString()), findsNWidgets(3));
+    // The contract result for the player's round shows below the toggle.
+    expect(find.text(roundResultDescription(round)), findsOneWidget);
   });
 
   testWidgets("play tab navigates tricks and highlights the winner",
       (tester) async {
     final round = playedOutRound(Random(17));
-    await tester.pumpWidget(wrap(DuplicateRoundDetailsDialog(
-        layout: testLayout(), round: round, onClose: () {})));
+    await tester.pumpWidget(wrapDialog(round, passedOutRound(Random(17))));
 
     await tester.tap(find.text("Play"));
     await tester.pump();
@@ -86,11 +104,41 @@ void main() {
     expect(find.text("Trick 1 of 13"), findsOneWidget);
   });
 
+  testWidgets("round toggle switches to the duplicate round", (tester) async {
+    final round = playedOutRound(Random(17));
+    await tester.pumpWidget(wrapDialog(round, passedOutRound(Random(17))));
+
+    // Advance into the player's round so we can verify the trick position
+    // resets when switching rounds.
+    await tester.tap(find.text("Play"));
+    await tester.pump();
+    await tester.tap(find.byIcon(Icons.chevron_right));
+    await tester.pump();
+    expect(find.text("Trick 2 of 13"), findsOneWidget);
+
+    await tester.tap(find.text("Duplicate"));
+    await tester.pump();
+    expect(find.text("Passed out"), findsOneWidget);
+    expect(find.text("No cards were played."), findsOneWidget);
+
+    // Bidding tab for the duplicate round shows its four passes.
+    await tester.tap(find.text("Bidding"));
+    await tester.pump();
+    expect(find.text(BidAction.pass().symbolString()), findsNWidgets(4));
+
+    // Back on the player's round, the trick position starts over.
+    await tester.tap(find.text("Your round"));
+    await tester.pump();
+    await tester.tap(find.text("Play"));
+    await tester.pump();
+    expect(find.text("Trick 1 of 13"), findsOneWidget);
+  });
+
   testWidgets("back button invokes onClose", (tester) async {
     final round = playedOutRound(Random(17));
     bool closed = false;
-    await tester.pumpWidget(wrap(DuplicateRoundDetailsDialog(
-        layout: testLayout(), round: round, onClose: () => closed = true)));
+    await tester.pumpWidget(wrapDialog(round, passedOutRound(Random(17)),
+        onClose: () => closed = true));
 
     await tester.tap(find.text("Back"));
     expect(closed, isTrue);

--- a/test/bridge_ui_widget_test.dart
+++ b/test/bridge_ui_widget_test.dart
@@ -126,12 +126,12 @@ void main() {
     await tester.pump();
     expect(find.text(BidAction.pass().symbolString()), findsNWidgets(4));
 
-    // Back on the player's round, the trick position starts over.
+    // Back on the player's round, the trick position is preserved.
     await tester.tap(find.text("Your round"));
     await tester.pump();
     await tester.tap(find.text("Play"));
     await tester.pump();
-    expect(find.text("Trick 1 of 13"), findsOneWidget);
+    expect(find.text("Trick 2 of 13"), findsOneWidget);
   });
 
   testWidgets("back button invokes onClose", (tester) async {

--- a/test/bridge_ui_widget_test.dart
+++ b/test/bridge_ui_widget_test.dart
@@ -62,6 +62,14 @@ void main() {
             Colors.amber;
     expect(find.byWidgetPredicate(hasWinnerBorder), findsOneWidget);
 
+    // The center arrow points at the trick leader's card position.
+    int arrowQuarterTurns() => tester
+        .widget<RotatedBox>(find.ancestor(
+            of: find.byIcon(Icons.arrow_upward),
+            matching: find.byType(RotatedBox)))
+        .quarterTurns;
+    expect(arrowQuarterTurns(), (round.previousTricks[0].leader + 2) % 4);
+
     // Back arrow is disabled on the first trick.
     final leftButton = tester.widget<IconButton>(
         find.widgetWithIcon(IconButton, Icons.chevron_left));
@@ -71,6 +79,7 @@ void main() {
     await tester.pump();
     expect(find.text("Trick 2 of 13"), findsOneWidget);
     expect(find.byWidgetPredicate(hasWinnerBorder), findsOneWidget);
+    expect(arrowQuarterTurns(), (round.previousTricks[1].leader + 2) % 4);
 
     await tester.tap(find.byIcon(Icons.chevron_left));
     await tester.pump();

--- a/test/bridge_ui_widget_test.dart
+++ b/test/bridge_ui_widget_test.dart
@@ -1,0 +1,89 @@
+import 'dart:math';
+
+import 'package:cards_with_cats/bridge/bridge.dart';
+import 'package:cards_with_cats/bridge_ui.dart';
+import 'package:cards_with_cats/cards/card.dart';
+import 'package:cards_with_cats/common_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+BridgeRound playedOutRound(Random rng) {
+  final match = BridgeMatch(rng);
+  final round = match.currentRound;
+  round.addBid(
+      PlayerBid(round.currentBidder(), BidAction.contract(1, Suit.clubs)));
+  for (int i = 0; i < 3; i++) {
+    round.addBid(PlayerBid(round.currentBidder(), BidAction.pass()));
+  }
+  while (!round.isOver()) {
+    final legal = round.legalPlaysForCurrentPlayer();
+    round.playCard(legal[rng.nextInt(legal.length)]);
+  }
+  return round;
+}
+
+Layout testLayout() => Layout()
+  ..displaySize = const Size(800, 600)
+  ..playerHeight = 75
+  ..padding = EdgeInsets.zero;
+
+Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  testWidgets("details dialog shows bidding table with seat letters",
+      (tester) async {
+    final round = playedOutRound(Random(17));
+    await tester.pumpWidget(wrap(DuplicateRoundDetailsDialog(
+        layout: testLayout(), round: round, onClose: () {})));
+
+    for (final seat in ["S", "W", "N", "E"]) {
+      expect(find.text(seat), findsOneWidget);
+    }
+    // The auction: one contract bid and three passes.
+    expect(find.text(BidAction.contract(1, Suit.clubs).symbolString()),
+        findsOneWidget);
+    expect(find.text(BidAction.pass().symbolString()), findsNWidgets(3));
+  });
+
+  testWidgets("play tab navigates tricks and highlights the winner",
+      (tester) async {
+    final round = playedOutRound(Random(17));
+    await tester.pumpWidget(wrap(DuplicateRoundDetailsDialog(
+        layout: testLayout(), round: round, onClose: () {})));
+
+    await tester.tap(find.text("Play"));
+    await tester.pump();
+    expect(find.text("Trick 1 of 13"), findsOneWidget);
+
+    bool hasWinnerBorder(Widget w) =>
+        w is Container &&
+        w.decoration is BoxDecoration &&
+        ((w.decoration as BoxDecoration).border as Border?)?.top.color ==
+            Colors.amber;
+    expect(find.byWidgetPredicate(hasWinnerBorder), findsOneWidget);
+
+    // Back arrow is disabled on the first trick.
+    final leftButton = tester.widget<IconButton>(
+        find.widgetWithIcon(IconButton, Icons.chevron_left));
+    expect(leftButton.onPressed, isNull);
+
+    await tester.tap(find.byIcon(Icons.chevron_right));
+    await tester.pump();
+    expect(find.text("Trick 2 of 13"), findsOneWidget);
+    expect(find.byWidgetPredicate(hasWinnerBorder), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.chevron_left));
+    await tester.pump();
+    expect(find.text("Trick 1 of 13"), findsOneWidget);
+  });
+
+  testWidgets("back button invokes onClose", (tester) async {
+    final round = playedOutRound(Random(17));
+    bool closed = false;
+    await tester.pumpWidget(wrap(DuplicateRoundDetailsDialog(
+        layout: testLayout(), round: round, onClose: () => closed = true)));
+
+    await tester.tap(find.text("Back"));
+    expect(closed, isTrue);
+  });
+}


### PR DESCRIPTION
Shows bidding and play history for both the player's round and the duplicate round. Also a small fix for saving match state after the remaining tricks are claimed.