### PR TITLE
Bidding fixes: game-forcing rebids and redouble escapes

### DIFF
--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -3926,9 +3926,12 @@ List<SaycRule>? rhoDoubleRules(BidAction opening) {
 }
 
 /// Advance partner's takeout double. `over` is the last bid in the auction;
-/// when RHO passed the advance is forced.
+/// when RHO passed the advance is forced. When RHO redoubled, all passes are
+/// suppressed: even a worthless hand runs to a suit rather than offering to
+/// defend a redoubled contract.
 List<SaycRule> advanceDoubleRules(
-    ContractBid theirOpening, ContractBid over, bool forced) {
+    ContractBid theirOpening, ContractBid over, bool forced,
+    {bool redoubled = false}) {
   final theirSuit = theirOpening.trump;
   final excluded = <Suit>{
     if (theirSuit != null) theirSuit,
@@ -3952,7 +3955,7 @@ List<SaycRule> advanceDoubleRules(
       require: (h) => h.suitHcp(theirSuit) >= 5,
     ));
   }
-  if (!forced) {
+  if (!forced && !redoubled) {
     rules.add(SaycRule(
       BidAction.pass(),
       BidMeaning(
@@ -3969,11 +3972,14 @@ List<SaycRule> advanceDoubleRules(
         rules.add(SaycRule(
           BidAction.contract(level, suit),
           BidMeaning(
-            description: forced
-                ? "Forced advance of the takeout double: best suit ($name), 0-8 points"
-                : "Advance of the takeout double: best suit ($name), 6-8 points",
-            totalPoints:
-                forced ? const Range(high: 8) : const Range(low: 6, high: 8),
+            description: redoubled
+                ? "Advance of the takeout double over the redouble: best suit ($name), 0-8 points"
+                : forced
+                    ? "Forced advance of the takeout double: best suit ($name), 0-8 points"
+                    : "Advance of the takeout double: best suit ($name), 6-8 points",
+            totalPoints: (forced || redoubled)
+                ? const Range(high: 8)
+                : const Range(low: 6, high: 8),
           ),
           require: (h) => best(h) == suit,
         ));
@@ -4046,6 +4052,30 @@ List<SaycRule> advanceDoubleRules(
     ));
   }
   return rules;
+}
+
+/// After our takeout double was redoubled and both partner and the opener
+/// passed, passing again would leave the opponents in a redoubled contract
+/// they are happy with; run to the best unbid suit (the double promised
+/// support for all of them).
+List<SaycRule> doublerRedoubleRescueRules(ContractBid theirOpening) {
+  final theirSuit = theirOpening.trump!;
+  Suit? best(HandAnalysis h) =>
+      bestSuit(h, Suit.values.where((s) => s != theirSuit));
+
+  return [
+    for (final suit in Suit.values)
+      if (suit != theirSuit)
+        SaycRule(
+          BidAction.contract(cheapestLevel(suit, theirOpening), suit),
+          BidMeaning(
+            description:
+                "Rescuing the redoubled takeout double: best suit (${_suitNames[suit]})",
+            suitLengths: {suit: const Range(low: 3)},
+          ),
+          require: (h) => best(h) == suit,
+        ),
+  ];
 }
 
 /// Advance partner's overcall; `over` is the last bid in the auction.
@@ -5146,7 +5176,8 @@ List<SaycRule>? saycRulesForAuction(List<BidAction> calls) {
         myActions.isEmpty &&
         oppActions.length <= 2 &&
         (calls[n - 1].bidType == BidType.pass ||
-            calls[n - 1].bidType == BidType.contract)) {
+            calls[n - 1].bidType == BidType.contract ||
+            calls[n - 1].bidType == BidType.redouble)) {
       final action = partnerActions[0];
       ContractBid? last;
       for (int i = n - 1; i >= 0; i--) {
@@ -5158,7 +5189,8 @@ List<SaycRule>? saycRulesForAuction(List<BidAction> calls) {
       if (last == null) return null;
       if (action.bidType == BidType.double) {
         return advanceDoubleRules(
-            openBid, last, calls[n - 1].bidType == BidType.pass);
+            openBid, last, calls[n - 1].bidType == BidType.pass,
+            redoubled: calls[n - 1].bidType == BidType.redouble);
       }
       if (action.bidType == BidType.contract) {
         // Partner acted in the balancing seat if their call followed two
@@ -5218,6 +5250,19 @@ List<SaycRule>? saycRulesForAuction(List<BidAction> calls) {
       if (last != null && last == partnerActions[0].contractBid) {
         return oneNtRebidRules(partnerActions[0]);
       }
+    }
+    if (myActions.length == 1 &&
+        myActions[0].bidType == BidType.double &&
+        partnerActions.isEmpty &&
+        oppActions.length == 2 &&
+        oppActions[1].bidType == BidType.redouble &&
+        openBid.trump != null &&
+        calls[n - 1].bidType == BidType.pass &&
+        calls[n - 2].bidType == BidType.pass) {
+      // My takeout double was redoubled, and partner's pass asked me to
+      // pick a suit; passing would end the auction in their redoubled
+      // contract.
+      return doublerRedoubleRescueRules(openBid);
     }
     return null;
   }

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -1821,6 +1821,17 @@ List<SaycRule> _rebidAfterNewSuitRules(
       ignoreInfo: true,
       require: (h) => h.count(mySuit) >= 6 && h.totalPoints <= 15,
     ),
+    if (_isMajor(mySuit))
+      SaycRule(
+        BidAction.contract(4, mySuit),
+        BidMeaning(
+          description: "Game rebid: self-sufficient $myName suit, 19-21",
+          totalPoints: const Range(low: 19, high: 21),
+          suitLengths: {mySuit: const Range(low: 6)},
+        ),
+        ignoreInfo: true,
+        require: (h) => h.count(mySuit) >= 6 && h.totalPoints >= 19,
+      ),
     SaycRule(
       BidAction.contract(cheapestLevel(mySuit, response) + 1, mySuit),
       BidMeaning(
@@ -1829,7 +1840,8 @@ List<SaycRule> _rebidAfterNewSuitRules(
         suitLengths: {mySuit: const Range(low: 6)},
       ),
       ignoreInfo: true,
-      require: (h) => h.count(mySuit) >= 6,
+      require: (h) =>
+          h.count(mySuit) >= 6 && (h.totalPoints <= 18 || !_isMajor(mySuit)),
     ),
   ]);
   // Jump shifts: 18+, lower-ranking suits only.

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -656,6 +656,20 @@ void main() {
           "3D"); // 17 total
     });
 
+    test("game rebid with self-sufficient major and 19+", () {
+      // 20 HCP + 3 length points: too strong for the invitational single
+      // jump, which partner may pass.
+      expect(
+          openingBid("AJ", "AKQT742", "A", "Q54",
+              history: ["1H", "pass", "1S", "pass"]),
+          "4H");
+      // 16-18 still makes the invitational jump rebid.
+      expect(
+          openingBid("32", "AKQT42", "K2", "Q54",
+              history: ["1H", "pass", "1S", "pass"]),
+          "3H"); // 16 total
+    });
+
     test("reverses require 17+", () {
       expect(
           openingBid("K2", "AQ32", "AKQ32", "32",

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1052,6 +1052,28 @@ void main() {
           "5C");
     });
 
+    test("of a takeout double over their redouble", () {
+      // Even with nothing, the advancer runs to a suit rather than leaving
+      // partner's takeout double in for a redoubled contract.
+      expect(openingBid("9642", "J843", "T74", "92", history: ["1S", "X", "XX"]),
+          "2H");
+      expect(openingBid("962", "J84", "T74", "9852", history: ["1S", "X", "XX"]),
+          "2C");
+    });
+
+    test("doubler rescues when their redouble is passed back around", () {
+      // Advancer's pass over the redouble asks the doubler to pick a suit;
+      // passing again would let the opponents play 1S redoubled.
+      expect(
+          openingBid("A8", "Q973", "QJ5", "KJ85",
+              history: ["1S", "X", "XX", "pass", "pass"]),
+          "2H");
+      expect(
+          openingBid("A8", "Q97", "QJ5", "KJ852",
+              history: ["1S", "X", "XX", "pass", "pass"]),
+          "2C");
+    });
+
     test("of an overcall", () {
       expect(openingBid("K32", "Q432", "432", "Q32", history: ["1D", "1S", "pass"]),
           "2S");


### PR DESCRIPTION
- With 19+ points and a strong major rebid game, rather than a jump rebid which partner can pass
- After takeout double is redoubled, escape to best suit rather than play a redoubled contract