### PR TITLE
More bidding fixes including missed games and underbidding strong hands

### DIFF
--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -612,6 +612,20 @@ List<SaycRule> _majorResponseRules(ContractBid opening) {
       },
     ),
   ));
+  // Game-forcing values with nothing above matching (no fit for the major,
+  // no 5-card heart suit, no 4-card minor): the classic SAYC answer is two
+  // clubs on a 3-card suit, keeping 4M available as a preemptive raise.
+  rules.add(SaycRule(
+    BidAction.contract(2, Suit.clubs),
+    BidMeaning(
+      description: "Two-over-one: 4+ clubs (occasionally 3 with no other "
+          "forcing response), 10+ points, forcing",
+      totalPoints: const Range(low: 10),
+      suitLengths: {Suit.clubs: const Range(low: 3)},
+    ),
+    ignoreInfo: true,
+    require: (h) => h.totalPoints >= 13 && h.count(Suit.clubs) >= 3,
+  ));
   return rules;
 }
 
@@ -665,10 +679,11 @@ List<SaycRule> _minorResponseRules(ContractBid opening) {
     SaycRule(
       BidAction.contract(3, suit),
       BidMeaning(
-        description: "Limit raise: 4+ $name, 11-12 points, no 4-card major",
-        totalPoints: const Range(low: 11, high: 12),
+        description: "Limit raise: 4+ $name, 11-13 points, no 4-card major",
+        totalPoints: const Range(low: 11, high: 13),
         suitLengths: {suit: const Range(low: 4), ...noMajor},
       ),
+      require: (h) => h.hcp <= 12,
     ),
     SaycRule(
       BidAction.noTrump(2),
@@ -682,8 +697,8 @@ List<SaycRule> _minorResponseRules(ContractBid opening) {
     SaycRule(
       BidAction.noTrump(3),
       BidMeaning(
-        description: "16-18 HCP, balanced, no 4-card major",
-        hcp: const Range(low: 16, high: 18),
+        description: "16+ HCP, balanced, no 4-card major",
+        hcp: const Range(low: 16),
         balanced: true,
         suitLengths: noMajor,
       ),

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -548,6 +548,17 @@ List<SaycRule> _majorResponseRules(ContractBid opening) {
         suitLengths: {suit: const Range(low: 4)},
       ),
     ),
+    // With a ten-card fit the partnership belongs in game on trumps alone,
+    // so this covers everything below Jacoby/splinter strength, including
+    // hands that would otherwise make a limit raise.
+    SaycRule(
+      BidAction.contract(4, suit),
+      BidMeaning(
+        description: "Preemptive raise to game: 5+ $name, 6-12 points",
+        totalPoints: const Range(low: 6, high: 12),
+        suitLengths: {suit: const Range(low: 5)},
+      ),
+    ),
     SaycRule(
       BidAction.contract(2, suit),
       BidMeaning(

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -1647,6 +1647,17 @@ List<SaycRule> _rebidAfter1ntResponseRules(ContractBid opening) {
       ignoreInfo: true,
       require: (h) => h.count(mySuit) >= 6 && h.totalPoints <= 15,
     ),
+    if (_isMajor(mySuit))
+      SaycRule(
+        BidAction.contract(4, mySuit),
+        BidMeaning(
+          description: "Game rebid: self-sufficient $name suit, 19-21",
+          totalPoints: const Range(low: 19, high: 21),
+          suitLengths: {mySuit: const Range(low: 6)},
+        ),
+        ignoreInfo: true,
+        require: (h) => h.count(mySuit) >= 6 && h.totalPoints >= 19,
+      ),
     SaycRule(
       BidAction.contract(3, mySuit),
       BidMeaning(
@@ -1655,7 +1666,8 @@ List<SaycRule> _rebidAfter1ntResponseRules(ContractBid opening) {
         suitLengths: {mySuit: const Range(low: 6)},
       ),
       ignoreInfo: true,
-      require: (h) => h.count(mySuit) >= 6,
+      require: (h) =>
+          h.count(mySuit) >= 6 && (h.totalPoints <= 18 || !_isMajor(mySuit)),
     ),
     SaycRule(
       BidAction.noTrump(2),
@@ -2405,23 +2417,27 @@ List<SaycRule> _responderRebidAfterSuitRules(
           )
         ];
       }
-      return [
-        SaycRule(
-          oGame,
-          BidMeaning(
-              description: "Accepting the invitation",
-              totalPoints: const Range(low: 8, high: 9)),
-          ignoreInfo: true,
-          require: (h) => h.totalPoints >= 8,
-        ),
-        SaycRule(
-          BidAction.pass(),
-          BidMeaning(
-              description: "Declining the invitation",
-              totalPoints: const Range(low: 6, high: 7)),
-          ignoreInfo: true,
-        ),
-      ];
+      if (rebid.count == 3) {
+        return [
+          SaycRule(
+            oGame,
+            BidMeaning(
+                description: "Accepting the invitation",
+                totalPoints: const Range(low: 8, high: 9)),
+            ignoreInfo: true,
+            require: (h) => h.totalPoints >= 8,
+          ),
+          SaycRule(
+            BidAction.pass(),
+            BidMeaning(
+                description: "Declining the invitation",
+                totalPoints: const Range(low: 6, high: 7)),
+            ignoreInfo: true,
+          ),
+        ];
+      }
+      // Opener jumped to game (or beyond) himself.
+      return passOnly("Respecting partner's signoff");
     }
     if (rebid == ContractBid.noTrump(2)) {
       // 18-19.

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -3969,23 +3969,27 @@ List<SaycRule> advanceDoubleRules(
       final level = cheapestLevel(suit, over);
       final name = _suitNames[suit]!;
       if (tier == "cheap") {
+        // When the invitational jump would land in game (see the jump tier)
+        // it doesn't exist, and the cheap advance covers everything below
+        // game-forcing strength.
+        final maxPoints = level + 1 < (_isMajor(suit) ? 4 : 5) ? 8 : 11;
         rules.add(SaycRule(
           BidAction.contract(level, suit),
           BidMeaning(
             description: redoubled
-                ? "Advance of the takeout double over the redouble: best suit ($name), 0-8 points"
+                ? "Advance of the takeout double over the redouble: best suit ($name), 0-$maxPoints points"
                 : forced
-                    ? "Forced advance of the takeout double: best suit ($name), 0-8 points"
-                    : "Advance of the takeout double: best suit ($name), 6-8 points",
+                    ? "Forced advance of the takeout double: best suit ($name), 0-$maxPoints points"
+                    : "Advance of the takeout double: best suit ($name), 6-$maxPoints points",
             totalPoints: (forced || redoubled)
-                ? const Range(high: 8)
-                : const Range(low: 6, high: 8),
+                ? Range(high: maxPoints)
+                : Range(low: 6, high: maxPoints),
           ),
           require: (h) => best(h) == suit,
         ));
       } else if (tier == "jump") {
         // An invitational jump must land below game; hands worth game use
-        // the "game" tier, and others just bid the suit.
+        // the "game" tier.
         if (level + 1 >= (_isMajor(suit) ? 4 : 5)) continue;
         rules.add(SaycRule(
           BidAction.contract(level + 1, suit),

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -1181,8 +1181,13 @@ Suit? _secondSuitChoice(
   });
   for (final s in candidates) {
     final level = cheapestLevel(s, over);
-    if (level >= 3) continue;
-    if (level >= 2 && _strainOrder(s) > _strainOrder(mySuit) && total < 17) {
+    // Three-level second suits show 15+ (17+ for a high reverse).
+    if (level > 3) continue;
+    if (level >= 3 &&
+        total < (_strainOrder(s) > _strainOrder(mySuit) ? 17 : 15)) {
+      continue;
+    }
+    if (level == 2 && _strainOrder(s) > _strainOrder(mySuit) && total < 17) {
       continue;
     }
     return s;
@@ -1971,8 +1976,11 @@ List<SaycRule> _rebidAfterNewSuitRules(
   for (final s in Suit.values) {
     if (s == mySuit || s == partnerSuit) continue;
     final level = cheapestLevel(s, response);
-    if (level >= 3) continue;
+    // A second suit at the three level (only after a two-level response)
+    // forces the auction higher, so it shows extra strength.
+    if (level > 3 || (level == 3 && response.count < 2)) continue;
     final isReverse = level >= 2 && _strainOrder(s) > _strainOrder(mySuit);
+    final highLevel = level >= 3;
     // Without a jump shift available in this suit, the simple second suit
     // has no upper limit.
     final hasJumpShift = _strainOrder(s) < _strainOrder(mySuit) &&
@@ -1981,16 +1989,19 @@ List<SaycRule> _rebidAfterNewSuitRules(
       BidAction.contract(level, s),
       BidMeaning(
         description: "Second suit: 4+ ${_suitNames[s]}"
-            "${isReverse ? ', reverse showing extra strength' : ''}",
+            "${isReverse ? ', reverse showing extra strength' : highLevel ? ', extra strength at the three level' : ''}",
         totalPoints: isReverse
-            ? const Range(low: 17, high: 21)
-            : hasJumpShift
-                ? const Range(low: 13, high: 17)
-                : const Range(low: 13),
+            ? const Range(low: 17)
+            : highLevel
+                ? const Range(low: 15)
+                : hasJumpShift
+                    ? const Range(low: 13, high: 17)
+                    : const Range(low: 13),
         suitLengths: {s: const Range(low: 4)},
       ),
       ignoreInfo: true,
       require: (h) =>
+          (!highLevel || h.totalPoints >= (isReverse ? 17 : 15)) &&
           _secondSuitChoice(h, mySuit, {mySuit, partnerSuit}, response) == s,
     ));
   }
@@ -2997,9 +3008,10 @@ List<SaycRule> _responderRebidAfterSuitRules(
   final isReverse =
       rebid.count >= 2 && _strainOrder(second) > _strainOrder(oSuit);
   final isJump = rebid.count > cheapestLevel(second, responseBid);
-  if (isReverse || isJump) {
-    // A reverse or jump shift shows 17+: responder moves toward game with
-    // 8+ and otherwise retreats as cheaply as possible.
+  if (isReverse || isJump || rebid.count >= 3) {
+    // A reverse or jump shift shows 17+ and a three-level second suit
+    // 15+: responder moves toward game with 8+ and otherwise retreats as
+    // cheaply as possible.
     final rules = <SaycRule>[];
     if (_isMajor(second)) {
       rules.add(SaycRule(
@@ -5183,6 +5195,54 @@ List<SaycRule> negativeDoubleResponseRebidRules(
     ];
   }
   if (rebid.trump == oSuit) {
+    if (rebid.count > cheapestLevel(oSuit, overcall)) {
+      // Opener jumped in his own suit, showing 16+: drive to game with
+      // 10+ instead of the usual 13.
+      return [
+        SaycRule(
+          BidAction.pass(),
+          BidMeaning(
+              description: "Declining opposite opener's jump rebid",
+              totalPoints: const Range(low: 6, high: 9)),
+          ignoreInfo: true,
+          require: (h) => h.totalPoints <= 9,
+        ),
+        if (cheapestLevel(null, rebid) <= 3)
+          SaycRule(
+            BidAction.noTrump(3),
+            BidMeaning(
+                description: "Bidding game with a stopper",
+                totalPoints: const Range(low: 10)),
+            ignoreInfo: true,
+            require: (h) => h.hasStopper(theirSuit),
+          ),
+        if (oMajor)
+          SaycRule(
+            BidAction.contract(4, oSuit),
+            BidMeaning(
+                description: "Bidding game",
+                totalPoints: const Range(low: 10),
+                suitLengths: {oSuit: const Range(low: 2)}),
+            ignoreInfo: true,
+            require: (h) => h.count(oSuit) >= 2,
+          )
+        else
+          SaycRule(
+            BidAction.contract(5, oSuit),
+            BidMeaning(
+                description: "Raising to game in $oName",
+                totalPoints: const Range(low: 10),
+                suitLengths: {oSuit: const Range(low: 3)}),
+            ignoreInfo: true,
+            require: (h) => h.count(oSuit) >= 3,
+          ),
+        SaycRule(
+            BidAction.pass(),
+            BidMeaning(
+                description: "No clear direction; settling for a partscore"),
+            ignoreInfo: true),
+      ];
+    }
     final rules = <SaycRule>[
       SaycRule(
         BidAction.pass(),
@@ -5191,16 +5251,6 @@ List<SaycRule> negativeDoubleResponseRebidRules(
             totalPoints: const Range(low: 6, high: 10)),
         ignoreInfo: true,
         require: (h) => h.totalPoints <= 10,
-      ),
-      SaycRule(
-        BidAction.contract(rebid.count + 1, oSuit),
-        BidMeaning(
-          description: "Inviting game in $oName: 3+ support",
-          totalPoints: const Range(low: 11, high: 12),
-          suitLengths: {oSuit: const Range(low: 3)},
-        ),
-        ignoreInfo: true,
-        require: (h) => h.totalPoints <= 12 && h.count(oSuit) >= 3,
       ),
     ];
     if (rebid.count == 2) {
@@ -5230,6 +5280,18 @@ List<SaycRule> negativeDoubleResponseRebidRules(
             totalPoints: const Range(low: 13)),
         ignoreInfo: true,
         require: (h) => h.totalPoints >= 13 && h.hasStopper(theirSuit),
+      ));
+    }
+    if (rebid.count + 1 < (oMajor ? 4 : 5)) {
+      rules.add(SaycRule(
+        BidAction.contract(rebid.count + 1, oSuit),
+        BidMeaning(
+          description: "Inviting game in $oName: 3+ support",
+          totalPoints: const Range(low: 11, high: 13),
+          suitLengths: {oSuit: const Range(low: 3)},
+        ),
+        ignoreInfo: true,
+        require: (h) => h.totalPoints <= 13 && h.count(oSuit) >= 3,
       ));
     }
     if (!oMajor && rebid.count == 4) {

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -290,7 +290,10 @@ int cheapestLevel(Suit? strain, ContractBid over) {
 // Opening bids
 // ---------------------------------------------------------------------------
 
-const Range _openingSuitPoints = Range(low: 13, high: 21);
+// One-level suit openings are 13+ total points; the ceiling is the 2C
+// opening's 22 HCP, so total points with length can exceed 21.
+const Range _openingSuitPoints = Range(low: 13);
+const Range _openingSuitHcp = Range(high: 21);
 
 List<SaycRule> openingRules() {
   final rules = <SaycRule>[
@@ -363,6 +366,7 @@ List<SaycRule> openingRules() {
       BidMeaning(
         description: "Opening hand with 5+ spades",
         totalPoints: _openingSuitPoints,
+        hcp: _openingSuitHcp,
         suitLengths: {Suit.spades: const Range(low: 5)},
       ),
       ignoreInfo: true,
@@ -376,6 +380,7 @@ List<SaycRule> openingRules() {
       BidMeaning(
         description: "Opening hand with 5+ hearts",
         totalPoints: _openingSuitPoints,
+        hcp: _openingSuitHcp,
         suitLengths: {Suit.hearts: const Range(low: 5)},
       ),
       ignoreInfo: true,
@@ -387,6 +392,7 @@ List<SaycRule> openingRules() {
         description: "Opening hand, 3+ diamonds "
             "(typically 4+; 3 only with exactly 4=4=3=2 shape), no 5-card major",
         totalPoints: _openingSuitPoints,
+        hcp: _openingSuitHcp,
         suitLengths: {
           Suit.spades: const Range(high: 4),
           Suit.hearts: const Range(high: 4),
@@ -405,6 +411,7 @@ List<SaycRule> openingRules() {
       BidMeaning(
         description: "Opening hand, 3+ clubs, no 5-card major",
         totalPoints: _openingSuitPoints,
+        hcp: _openingSuitHcp,
         suitLengths: {
           Suit.spades: const Range(high: 4),
           Suit.hearts: const Range(high: 4),
@@ -1601,7 +1608,7 @@ List<SaycRule> _rebidAfterRaiseRules(ContractBid opening, ContractBid response) 
         BidAction.contract(gameLevel, mySuit),
         BidMeaning(
             description: "Accepting game",
-            totalPoints: const Range(low: 19, high: 21)),
+            totalPoints: const Range(low: 19)),
         ignoreInfo: true,
       ),
     ];
@@ -1621,7 +1628,7 @@ List<SaycRule> _rebidAfterRaiseRules(ContractBid opening, ContractBid response) 
         BidAction.contract(gameLevel, mySuit),
         BidMeaning(
             description: "Accepting the game invitation",
-            totalPoints: const Range(low: 14, high: 21)),
+            totalPoints: const Range(low: 14)),
         ignoreInfo: true,
       ),
     ];
@@ -1651,13 +1658,40 @@ List<SaycRule> _rebidAfter1ntResponseRules(ContractBid opening) {
       SaycRule(
         BidAction.contract(4, mySuit),
         BidMeaning(
-          description: "Game rebid: self-sufficient $name suit, 19-21",
-          totalPoints: const Range(low: 19, high: 21),
+          description: "Game rebid: self-sufficient $name suit, 19+",
+          totalPoints: const Range(low: 19),
           suitLengths: {mySuit: const Range(low: 6)},
         ),
         ignoreInfo: true,
         require: (h) => h.count(mySuit) >= 6 && h.totalPoints >= 19,
       ),
+    // With a long minor and 19+, gamble 3NT with the other suits stopped;
+    // otherwise force with a jump to four of the minor.
+    if (!_isMajor(mySuit)) ...[
+      SaycRule(
+        BidAction.noTrump(3),
+        BidMeaning(
+          description: "Long $name suit and 19+ points, other suits stopped",
+          totalPoints: const Range(low: 19),
+          suitLengths: {mySuit: const Range(low: 6)},
+        ),
+        ignoreInfo: true,
+        require: (h) =>
+            h.count(mySuit) >= 6 &&
+            h.totalPoints >= 19 &&
+            Suit.values.where((su) => su != mySuit).every(h.hasStopper),
+      ),
+      SaycRule(
+        BidAction.contract(4, mySuit),
+        BidMeaning(
+          description: "Game-forcing rebid: 6+ $name, 19+ points",
+          totalPoints: const Range(low: 19),
+          suitLengths: {mySuit: const Range(low: 6)},
+        ),
+        ignoreInfo: true,
+        require: (h) => h.count(mySuit) >= 6 && h.totalPoints >= 19,
+      ),
+    ],
     SaycRule(
       BidAction.contract(3, mySuit),
       BidMeaning(
@@ -1666,8 +1700,7 @@ List<SaycRule> _rebidAfter1ntResponseRules(ContractBid opening) {
         suitLengths: {mySuit: const Range(low: 6)},
       ),
       ignoreInfo: true,
-      require: (h) =>
-          h.count(mySuit) >= 6 && (h.totalPoints <= 18 || !_isMajor(mySuit)),
+      require: (h) => h.count(mySuit) >= 6 && h.totalPoints <= 18,
     ),
     SaycRule(
       BidAction.noTrump(2),
@@ -1694,7 +1727,7 @@ List<SaycRule> _rebidAfter1ntResponseRules(ContractBid opening) {
       BidAction.contract(3, s),
       BidMeaning(
         description: "Jump shift: 4+ ${_suitNames[s]}, 18+ points",
-        totalPoints: const Range(low: 18, high: 21),
+        totalPoints: const Range(low: 18),
         suitLengths: {s: const Range(low: 4)},
       ),
       ignoreInfo: true,
@@ -1727,7 +1760,7 @@ List<SaycRule> _rebidAfter1ntResponseRules(ContractBid opening) {
     BidAction.pass(),
     BidMeaning(
         description: "Minimum with no better rebid",
-        totalPoints: const Range(low: 13, high: 15)),
+        totalPoints: const Range(low: 13, high: 16)),
     ignoreInfo: true,
   ));
   return rules;
@@ -1758,7 +1791,8 @@ List<SaycRule> _rebidAfterNewSuitRules(
         BidAction.contract(response.count + 2, partnerSuit),
         BidMeaning(
           description: "Jump raise: 4+ $pName, extra values",
-          totalPoints: const Range(low: 16, high: 18),
+          totalPoints:
+              partnerMajor ? const Range(low: 16, high: 18) : const Range(low: 16),
           suitLengths: {partnerSuit: const Range(low: 4)},
         ),
         ignoreInfo: true,
@@ -1793,7 +1827,7 @@ List<SaycRule> _rebidAfterNewSuitRules(
           BidAction.contract(1, major),
           BidMeaning(
             description: "Second suit: 4+ ${_suitNames[major]}",
-            totalPoints: const Range(low: 13, high: 18),
+            totalPoints: const Range(low: 13),
             suitLengths: {major: const Range(low: 4)},
           ),
           ignoreInfo: true,
@@ -1837,13 +1871,42 @@ List<SaycRule> _rebidAfterNewSuitRules(
       SaycRule(
         BidAction.contract(4, mySuit),
         BidMeaning(
-          description: "Game rebid: self-sufficient $myName suit, 19-21",
-          totalPoints: const Range(low: 19, high: 21),
+          description: "Game rebid: self-sufficient $myName suit, 19+",
+          totalPoints: const Range(low: 19),
           suitLengths: {mySuit: const Range(low: 6)},
         ),
         ignoreInfo: true,
         require: (h) => h.count(mySuit) >= 6 && h.totalPoints >= 19,
       ),
+    // With a long minor and 19+, gamble 3NT with the unbid suits stopped;
+    // otherwise force with a jump to four of the minor.
+    if (!_isMajor(mySuit)) ...[
+      SaycRule(
+        BidAction.noTrump(3),
+        BidMeaning(
+          description: "Long $myName suit and 19+ points, other suits stopped",
+          totalPoints: const Range(low: 19),
+          suitLengths: {mySuit: const Range(low: 6)},
+        ),
+        ignoreInfo: true,
+        require: (h) =>
+            h.count(mySuit) >= 6 &&
+            h.totalPoints >= 19 &&
+            Suit.values
+                .where((su) => su != mySuit && su != partnerSuit)
+                .every(h.hasStopper),
+      ),
+      SaycRule(
+        BidAction.contract(4, mySuit),
+        BidMeaning(
+          description: "Game-forcing rebid: 6+ $myName, 19+ points",
+          totalPoints: const Range(low: 19),
+          suitLengths: {mySuit: const Range(low: 6)},
+        ),
+        ignoreInfo: true,
+        require: (h) => h.count(mySuit) >= 6 && h.totalPoints >= 19,
+      ),
+    ],
     SaycRule(
       BidAction.contract(cheapestLevel(mySuit, response) + 1, mySuit),
       BidMeaning(
@@ -1852,8 +1915,7 @@ List<SaycRule> _rebidAfterNewSuitRules(
         suitLengths: {mySuit: const Range(low: 6)},
       ),
       ignoreInfo: true,
-      require: (h) =>
-          h.count(mySuit) >= 6 && (h.totalPoints <= 18 || !_isMajor(mySuit)),
+      require: (h) => h.count(mySuit) >= 6 && h.totalPoints <= 18,
     ),
   ]);
   // Jump shifts: 18+, lower-ranking suits only.
@@ -1869,7 +1931,7 @@ List<SaycRule> _rebidAfterNewSuitRules(
       BidAction.contract(jumpLevel, s),
       BidMeaning(
         description: "Jump shift: 4+ ${_suitNames[s]}, 18+ points",
-        totalPoints: const Range(low: 18, high: 21),
+        totalPoints: const Range(low: 18),
         suitLengths: {s: const Range(low: 4)},
       ),
       ignoreInfo: true,
@@ -1883,6 +1945,10 @@ List<SaycRule> _rebidAfterNewSuitRules(
     final level = cheapestLevel(s, response);
     if (level >= 3) continue;
     final isReverse = level >= 2 && _strainOrder(s) > _strainOrder(mySuit);
+    // Without a jump shift available in this suit, the simple second suit
+    // has no upper limit.
+    final hasJumpShift = _strainOrder(s) < _strainOrder(mySuit) &&
+        cheapestLevel(s, response) + 1 <= 3;
     rules.add(SaycRule(
       BidAction.contract(level, s),
       BidMeaning(
@@ -1890,7 +1956,9 @@ List<SaycRule> _rebidAfterNewSuitRules(
             "${isReverse ? ', reverse showing extra strength' : ''}",
         totalPoints: isReverse
             ? const Range(low: 17, high: 21)
-            : const Range(low: 13, high: 17),
+            : hasJumpShift
+                ? const Range(low: 13, high: 17)
+                : const Range(low: 13),
         suitLengths: {s: const Range(low: 4)},
       ),
       ignoreInfo: true,
@@ -1902,7 +1970,7 @@ List<SaycRule> _rebidAfterNewSuitRules(
     BidAction.contract(cheapestLevel(mySuit, response), mySuit),
     BidMeaning(
       description: "Suit rebid, minimum with no better option",
-      totalPoints: const Range(low: 13, high: 16),
+      totalPoints: const Range(low: 13),
       suitLengths: {mySuit: Range(low: _isMajor(mySuit) ? 5 : 3)},
     ),
     ignoreInfo: true,
@@ -2042,7 +2110,7 @@ List<SaycRule>? _responderRebidAfter1ntRules(
           BidAction.contract(4, major),
           BidMeaning(
             description: "Raise to game: 4 $name",
-            hcp: const Range(low: 10, high: 15),
+            hcp: const Range(low: 10),
             suitLengths: {major: const Range(low: 4)},
           ),
           ignoreInfo: true,
@@ -2063,7 +2131,7 @@ List<SaycRule>? _responderRebidAfter1ntRules(
         BidAction.noTrump(3),
         BidMeaning(
             description: "To play, no major-suit fit",
-            hcp: const Range(low: 10, high: 15)),
+            hcp: const Range(low: 10)),
         ignoreInfo: true,
       ),
     ]);
@@ -2114,7 +2182,7 @@ List<SaycRule>? _responderRebidAfter1ntRules(
         BidMeaning(
           description:
               "Choice of games: exactly 5 $name, opener corrects with a fit",
-          hcp: const Range(low: 10, high: 15),
+          hcp: const Range(low: 10),
           suitLengths: {major: const Range(low: 5, high: 5)},
         ),
         ignoreInfo: true,
@@ -2524,7 +2592,7 @@ List<SaycRule> _responderRebidAfterSuitRules(
           BidAction.contract(cheapestLevel(oSuit, rebid), oSuit),
           BidMeaning(
               description: "Preference to $oName, no extra values",
-              totalPoints: const Range(low: 6, high: 9)),
+              totalPoints: const Range(low: 6, high: 10)),
           ignoreInfo: true,
           require: (h) => h.count(oSuit) >= h.count(second),
         ),
@@ -3474,8 +3542,9 @@ List<SaycRule> _oneSuitOpenerThirdRules(
     // We rebid our own suit.
     final single = rebidBid.count == cheapestLevel(oSuit, responseBid);
     final threshold = single ? 14 : 17;
+    // The cheapest rebid is unlimited when the hand had no better option.
     final shown =
-        single ? const Range(low: 13, high: 15) : const Range(low: 16, high: 18);
+        single ? const Range(low: 13) : const Range(low: 16, high: 18);
     final gameLevel = _isMajor(oSuit) ? 4 : 5;
     if (r2.trump == oSuit &&
         r2.count == rebidBid.count + 1 &&
@@ -3546,14 +3615,14 @@ List<SaycRule> _oneSuitOpenerThirdRules(
   }
   if (r2 == ContractBid.noTrump(2)) {
     return inviteRules(
-        BidAction.noTrump(3), 15, const Range(low: 13, high: 18), false);
+        BidAction.noTrump(3), 15, const Range(low: 13), false);
   }
   if (r2.trump == rebidBid.trump &&
       r2.count == rebidBid.count + 2 &&
       r2.count < (_isMajor(rebidBid.trump!) ? 4 : 5)) {
     // Invitational jump raise of the second suit.
     return inviteRules(
-        suitGame(rebidBid.trump!), 15, const Range(low: 13, high: 18), false);
+        suitGame(rebidBid.trump!), 15, const Range(low: 13), false);
   }
   return defaultRules;
 }
@@ -3672,7 +3741,7 @@ List<SaycRule> directActionRules(ContractBid opening,
         BidMeaning(
           description:
               "Overcall of their preempt: 5+ ${_suitNames[suit]}, opening values",
-          totalPoints: const Range(low: 13, high: 17),
+          totalPoints: const Range(low: 13),
           suitLengths: {suit: const Range(low: 5)},
         ),
         ignoreInfo: true,
@@ -3910,7 +3979,7 @@ List<SaycRule> interferenceResponseRules(
       BidMeaning(
           description:
               "Game values with a ${_suitNames[overcallSuit]} stopper",
-          totalPoints: const Range(low: 13, high: 15)),
+          totalPoints: const Range(low: 13)),
       ignoreInfo: true,
       require: (h) => h.totalPoints >= 13 && h.hasStopper(overcallSuit),
     ));
@@ -4350,7 +4419,7 @@ List<SaycRule> reopeningRules(ContractBid opening, ContractBid overcall) {
       BidAction.contract(cheapestLevel(mySuit, overcall), mySuit),
       BidMeaning(
         description: "Reopening rebid: 6+ $myName",
-        totalPoints: const Range(low: 13, high: 16),
+        totalPoints: const Range(low: 13),
         suitLengths: {mySuit: const Range(low: 6)},
       ),
       ignoreInfo: true,
@@ -4379,7 +4448,7 @@ List<SaycRule> reopeningRules(ContractBid opening, ContractBid overcall) {
         description: "Second suit: 4+ ${_suitNames[s]}",
         totalPoints: isReverse
             ? const Range(low: 17, high: 21)
-            : const Range(low: 13, high: 18),
+            : const Range(low: 13),
         suitLengths: {s: const Range(low: 4)},
       ),
       ignoreInfo: true,
@@ -4415,7 +4484,7 @@ List<SaycRule> sandwichActionRules(ContractBid firstBid, ContractBid secondBid) 
         BidMeaning(
           description: "Overcall over their notrump response: "
               "5+ ${_suitNames[s]}, opening values",
-          totalPoints: const Range(low: 13, high: 17),
+          totalPoints: const Range(low: 13),
           suitLengths: {s: const Range(low: 5)},
         ),
         ignoreInfo: true,
@@ -4465,7 +4534,7 @@ List<SaycRule> sandwichActionRules(ContractBid firstBid, ContractBid secondBid) 
         BidMeaning(
           description:
               "Overcall of their raised suit: 5+ ${_suitNames[s]}, opening values",
-          totalPoints: const Range(low: 13, high: 17),
+          totalPoints: const Range(low: 13),
           suitLengths: {s: const Range(low: 5)},
         ),
         ignoreInfo: true,
@@ -4523,7 +4592,7 @@ List<SaycRule> sandwichActionRules(ContractBid firstBid, ContractBid secondBid) 
         BidAction.contract(level, s),
         BidMeaning(
           description: "Sandwich overcall: 5+ ${_suitNames[s]}, opening values",
-          totalPoints: const Range(low: 13, high: 17),
+          totalPoints: const Range(low: 13),
           suitLengths: {s: const Range(low: 5)},
         ),
         ignoreInfo: true,
@@ -4616,15 +4685,29 @@ List<SaycRule> negativeDoubleRebidRules(
       ignoreInfo: true,
       require: (h) => h.count(mySuit) >= 6 && h.totalPoints <= 15,
     ),
+    if (_isMajor(mySuit))
+      SaycRule(
+        BidAction.contract(4, mySuit),
+        BidMeaning(
+          description: "Game rebid: self-sufficient $myName suit, 19+",
+          totalPoints: const Range(low: 19),
+          suitLengths: {mySuit: const Range(low: 6)},
+        ),
+        ignoreInfo: true,
+        require: (h) => h.count(mySuit) >= 6 && h.totalPoints >= 19,
+      ),
     SaycRule(
       BidAction.contract(cheapestLevel(mySuit, overcall) + 1, mySuit),
       BidMeaning(
         description: "6+ $myName, extra values",
-        totalPoints: const Range(low: 16, high: 18),
+        totalPoints: _isMajor(mySuit)
+            ? const Range(low: 16, high: 18)
+            : const Range(low: 16),
         suitLengths: {mySuit: const Range(low: 6)},
       ),
       ignoreInfo: true,
-      require: (h) => h.count(mySuit) >= 6,
+      require: (h) =>
+          h.count(mySuit) >= 6 && (h.totalPoints <= 18 || !_isMajor(mySuit)),
     ),
   ]);
   for (final s in Suit.values) {
@@ -4638,7 +4721,7 @@ List<SaycRule> negativeDoubleRebidRules(
         description: "Second suit: 4+ ${_suitNames[s]}",
         totalPoints: isReverse
             ? const Range(low: 17, high: 21)
-            : const Range(low: 13, high: 18),
+            : const Range(low: 13),
         suitLengths: {s: const Range(low: 4)},
       ),
       ignoreInfo: true,
@@ -4650,7 +4733,7 @@ List<SaycRule> negativeDoubleRebidRules(
     BidAction.contract(cheapestLevel(mySuit, overcall), mySuit),
     BidMeaning(
       description: "Suit rebid, no better option",
-      totalPoints: const Range(low: 13, high: 16),
+      totalPoints: const Range(low: 13),
       suitLengths: {mySuit: Range(low: _isMajor(mySuit) ? 5 : 3)},
     ),
     ignoreInfo: true,

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -4233,6 +4233,265 @@ List<SaycRule> doublerRedoubleRescueRules(ContractBid theirOpening) {
   ];
 }
 
+/// The takeout doubler's second call after partner advanced in a suit and
+/// the opponents passed. `over` is the contract the advance was bid over
+/// (for detecting an invitational jump).
+List<SaycRule> doublerRebidRules(
+    ContractBid theirOpening, ContractBid over, ContractBid advance) {
+  final theirSuit = theirOpening.trump!;
+  final aSuit = advance.trump!;
+  final gameLevel = _isMajor(aSuit) ? 4 : 5;
+  if (advance.count >= gameLevel) {
+    return [
+      SaycRule(BidAction.pass(),
+          BidMeaning(description: "Respecting partner's game decision"))
+    ];
+  }
+
+  if (advance.count > cheapestLevel(aSuit, over)) {
+    // The invitational jump advance (9-11): accept with a bit extra.
+    return [
+      if (!_isMajor(aSuit))
+        SaycRule(
+          BidAction.noTrump(3),
+          BidMeaning(
+              description: "Accepting the invitation in notrump",
+              totalPoints: const Range(low: 15)),
+          ignoreInfo: true,
+          require: (h) =>
+              h.totalPoints >= 15 &&
+              h.hasStopper(theirSuit) &&
+              cheapestLevel(null, advance) <= 3,
+        ),
+      SaycRule(
+        BidAction.contract(gameLevel, aSuit),
+        BidMeaning(
+            description: "Accepting the invitation",
+            totalPoints: const Range(low: 15)),
+        ignoreInfo: true,
+        require: (h) => h.totalPoints >= 15,
+      ),
+      SaycRule(
+        BidAction.pass(),
+        BidMeaning(
+            description: "Declining the invitation",
+            totalPoints: const Range(high: 14)),
+        ignoreInfo: true,
+      ),
+    ];
+  }
+
+  // Partner's advance was forced and may be worthless; bidding on shows
+  // the big-hand (17+) double.
+  final rules = <SaycRule>[];
+  for (final s in [Suit.spades, Suit.hearts]) {
+    if (s == theirSuit || s == aSuit || cheapestLevel(s, advance) > 4) {
+      continue;
+    }
+    rules.add(SaycRule(
+      BidAction.contract(4, s),
+      BidMeaning(
+        description: "Doubled intending to bid: self-sufficient "
+            "${_suitNames[s]} suit, 20+ points",
+        totalPoints: const Range(low: 20),
+        suitLengths: {s: const Range(low: 6)},
+      ),
+      ignoreInfo: true,
+      require: (h) =>
+          h.totalPoints >= 20 && h.count(s) >= 6 && h.topHonorCount(s) >= 2,
+    ));
+  }
+  rules.addAll([
+    SaycRule(
+      BidAction.noTrump(3),
+      BidMeaning(
+          description:
+              "Doubled with game in hand: 21+ HCP, ${_suitNames[theirSuit]} stopped",
+          hcp: const Range(low: 21)),
+      ignoreInfo: true,
+      require: (h) =>
+          h.hcp >= 21 &&
+          h.hasStopper(theirSuit) &&
+          cheapestLevel(null, advance) <= 3,
+    ),
+    SaycRule(
+      BidAction.contract(gameLevel, aSuit),
+      BidMeaning(
+        description: "Raising the forced advance to game: 20+ points",
+        totalPoints: const Range(low: 20),
+        suitLengths: {aSuit: const Range(low: 3)},
+      ),
+      ignoreInfo: true,
+      require: (h) => h.totalPoints >= 20 && h.count(aSuit) >= 3,
+    ),
+    if (advance.count + 1 < gameLevel)
+      SaycRule(
+        BidAction.contract(advance.count + 1, aSuit),
+        BidMeaning(
+          description: "Raising the forced advance: 17-19 points",
+          totalPoints: const Range(low: 17, high: 19),
+          suitLengths: {aSuit: const Range(low: 3)},
+        ),
+        ignoreInfo: true,
+        require: (h) => h.totalPoints >= 17 && h.count(aSuit) >= 3,
+      ),
+    SaycRule(
+      BidAction.noTrump(cheapestLevel(null, advance)),
+      BidMeaning(
+          description: "Doubled then notrump: 18-20 HCP, "
+              "${_suitNames[theirSuit]} stopped",
+          hcp: const Range(low: 18, high: 20),
+          balanced: true),
+      ignoreInfo: true,
+      require: (h) =>
+          h.isBalanced &&
+          h.hcp >= 18 &&
+          h.hasStopper(theirSuit) &&
+          cheapestLevel(null, advance) <= 2,
+    ),
+  ]);
+  // A new suit (too strong to overcall).
+  for (final su in Suit.values) {
+    if (su == theirSuit || su == aSuit) continue;
+    final level = cheapestLevel(su, advance);
+    if (level > 3) continue;
+    rules.add(SaycRule(
+      BidAction.contract(level, su),
+      BidMeaning(
+        description:
+            "Doubled intending to bid ${_suitNames[su]}: 17+ points, 5+ cards",
+        totalPoints: const Range(low: 17),
+        suitLengths: {su: const Range(low: 5)},
+      ),
+      ignoreInfo: true,
+      require: (h) =>
+          h.totalPoints >= 17 &&
+          h.count(su) >= 5 &&
+          bestSuit(h, Suit.values.where((x) => x != theirSuit && x != aSuit)) ==
+              su,
+    ));
+  }
+  rules.add(SaycRule(
+    BidAction.pass(),
+    BidMeaning(description: "Minimum double with nothing more to say"),
+    ignoreInfo: true,
+  ));
+  return rules;
+}
+
+/// The overcaller's rebid after partner advanced in a new suit (neither
+/// ours nor the opponents') and the opponents passed.
+List<SaycRule> overcallerNewSuitRebidRules(
+    ContractBid theirOpening, ContractBid myOvercall, ContractBid advance) {
+  final theirSuit = theirOpening.trump!;
+  final mySuit = myOvercall.trump!;
+  final myName = _suitNames[mySuit]!;
+  final aSuit = advance.trump!;
+  final aName = _suitNames[aSuit]!;
+  final gameLevel = _isMajor(aSuit) ? 4 : 5;
+  if (advance.count >= gameLevel) {
+    return [
+      SaycRule(BidAction.pass(),
+          BidMeaning(description: "Respecting partner's game decision"))
+    ];
+  }
+  // A new suit at the three level is forcing; at the two level it is
+  // constructive and may be passed with a misfit minimum.
+  final forcing = advance.count >= 3;
+
+  final ownMajorGame = SaycRule(
+    BidAction.contract(4, mySuit),
+    BidMeaning(
+      description: "Game rebid: self-sufficient $myName suit, maximum overcall",
+      totalPoints: const Range(low: 14),
+      suitLengths: {mySuit: const Range(low: 6)},
+    ),
+    ignoreInfo: true,
+    require: (h) =>
+        h.totalPoints >= 14 &&
+        h.count(mySuit) >= 6 &&
+        h.topHonorCount(mySuit) >= 2,
+  );
+  final gameRaise = SaycRule(
+    BidAction.contract(gameLevel, aSuit),
+    BidMeaning(
+      description: "Raising partner's $aName to game",
+      totalPoints: Range(low: forcing ? 13 : 14),
+      suitLengths: {aSuit: Range(low: forcing ? 2 : 3)},
+    ),
+    ignoreInfo: true,
+    require: (h) =>
+        h.totalPoints >= (forcing ? 13 : 14) &&
+        h.count(aSuit) >= (forcing ? 2 : 3),
+  );
+  final nt3 = SaycRule(
+    BidAction.noTrump(3),
+    BidMeaning(
+        description:
+            "Game in notrump with ${_suitNames[theirSuit]} stopped",
+        totalPoints: const Range(low: 13)),
+    ignoreInfo: true,
+    require: (h) =>
+        h.totalPoints >= 13 &&
+        h.hasStopper(theirSuit) &&
+        cheapestLevel(null, advance) <= 3,
+  );
+
+  final rules = <SaycRule>[
+    if (_isMajor(mySuit)) ownMajorGame,
+    ...(_isMajor(aSuit) ? [gameRaise, nt3] : [nt3, gameRaise]),
+    if (advance.count + 1 < gameLevel)
+      SaycRule(
+        BidAction.contract(advance.count + 1, aSuit),
+        BidMeaning(
+          description: "Raising partner's $aName",
+          totalPoints: const Range(low: 11, high: 13),
+          suitLengths: {aSuit: const Range(low: 3)},
+        ),
+        ignoreInfo: true,
+        require: (h) => h.totalPoints >= 11 && h.count(aSuit) >= 3,
+      ),
+    if (cheapestLevel(mySuit, advance) <= 3)
+      SaycRule(
+        BidAction.contract(cheapestLevel(mySuit, advance), mySuit),
+        BidMeaning(
+          description: "Rebidding a 6+ card $myName suit",
+          suitLengths: {mySuit: const Range(low: 6)},
+        ),
+        ignoreInfo: true,
+        require: (h) => h.count(mySuit) >= 6,
+      ),
+    if (cheapestLevel(null, advance) <= 2)
+      SaycRule(
+        BidAction.noTrump(cheapestLevel(null, advance)),
+        BidMeaning(
+            description:
+                "Notrump with ${_suitNames[theirSuit]} stopped",
+            hcp: const Range(low: 11, high: 14)),
+        ignoreInfo: true,
+        require: (h) => h.hcp >= 11 && h.hasStopper(theirSuit),
+      ),
+    if (forcing)
+      SaycRule(
+        BidAction.contract(cheapestLevel(mySuit, advance), mySuit),
+        BidMeaning(
+          description: "Forced rebid of the overcalled suit",
+          suitLengths: {mySuit: const Range(low: 5)},
+        ),
+        ignoreInfo: true,
+      )
+    else
+      SaycRule(
+        BidAction.pass(),
+        BidMeaning(
+            description: "No fit and no descriptive rebid",
+            totalPoints: const Range(high: 16)),
+        ignoreInfo: true,
+      ),
+  ];
+  return rules;
+}
+
 /// Advance partner's overcall; `over` is the last bid in the auction.
 List<SaycRule>? advanceOvercallRules(
     ContractBid theirOpening, ContractBid overcall, ContractBid over,
@@ -5470,6 +5729,45 @@ List<SaycRule>? saycRulesForAuction(List<BidAction> calls) {
             ntRange: balancing
                 ? const Range(low: 11, high: 16)
                 : const Range(low: 15, high: 18));
+      }
+    }
+    if (myActions.length == 1 &&
+        partnerActions.length == 1 &&
+        isSuitBid(partnerActions[0]) &&
+        openBid.trump != null &&
+        oppActions.length <= 2 &&
+        calls[n - 1].bidType == BidType.pass) {
+      // Partner advanced my takeout double or overcall in a suit that is
+      // neither ours nor the opponents'; choose our rebid.
+      final advance = partnerActions[0].contractBid!;
+      int partnerIndex = -1;
+      for (int i = 0; i < n; i++) {
+        if ((n - i) % 4 == 2 && calls[i].bidType != BidType.pass) {
+          partnerIndex = i;
+          break;
+        }
+      }
+      // The advance must be the last bid, with nothing by the opponents
+      // after it.
+      final noneAfter = calls
+          .sublist(partnerIndex + 1)
+          .every((c) => c.bidType == BidType.pass);
+      ContractBid? over;
+      for (int i = partnerIndex - 1; i >= 0; i--) {
+        if (calls[i].bidType == BidType.contract) {
+          over = calls[i].contractBid;
+          break;
+        }
+      }
+      if (noneAfter && over != null && advance.trump != openBid.trump) {
+        if (myActions[0].bidType == BidType.double) {
+          return doublerRebidRules(openBid, over, advance);
+        }
+        if (isSuitBid(myActions[0]) &&
+            advance.trump != myActions[0].contractBid!.trump) {
+          return overcallerNewSuitRebidRules(
+              openBid, myActions[0].contractBid!, advance);
+        }
       }
     }
     if (myActions.length == 1 &&

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -3984,7 +3984,9 @@ List<SaycRule> advanceDoubleRules(
           require: (h) => best(h) == suit,
         ));
       } else if (tier == "jump") {
-        if (level + 1 > 4) continue; // never jump past game
+        // An invitational jump must land below game; hands worth game use
+        // the "game" tier, and others just bid the suit.
+        if (level + 1 >= (_isMajor(suit) ? 4 : 5)) continue;
         rules.add(SaycRule(
           BidAction.contract(level + 1, suit),
           BidMeaning(
@@ -4303,15 +4305,25 @@ List<SaycRule> reopeningRules(ContractBid opening, ContractBid overcall) {
   final theirSuit = overcall.trump!;
   final theirName = _suitNames[theirSuit]!;
 
+  // A one-level reopening double can be light and shape-flexible, but
+  // doubling a higher overcall forces partner to answer at that level, so
+  // it promises support for the unbid majors.
+  final unbidMajors = [Suit.spades, Suit.hearts]
+      .where((s) => s != mySuit && s != theirSuit && overcall.count >= 2);
   final rules = <SaycRule>[
     SaycRule(
       BidAction.double(),
       BidMeaning(
         description:
-            "Reopening takeout double: at most two $theirName (partner may pass for penalty)",
+            "Reopening takeout double: at most two $theirName"
+            "${unbidMajors.isNotEmpty ? ', support for the unbid majors' : ''}"
+            " (partner may pass for penalty)",
         totalPoints: const Range(low: 13, high: 21),
         artificial: true,
-        suitLengths: {theirSuit: const Range(high: 2)},
+        suitLengths: {
+          theirSuit: const Range(high: 2),
+          for (final s in unbidMajors) s: const Range(low: 3),
+        },
       ),
     ),
     SaycRule(

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -2532,6 +2532,18 @@ List<SaycRule> _responderRebidAfterSuitRules(
           ),
         ];
       }
+      if (!oMajor && rebid.count == 4) {
+        // The double jump to four of the minor shows 19+ and forces to
+        // game; we have no suit of our own after 1NT, so raise.
+        return [
+          SaycRule(
+            BidAction.contract(5, oSuit),
+            BidMeaning(
+                description: "Raising the game-forcing rebid to game"),
+            ignoreInfo: true,
+          )
+        ];
+      }
       // Opener jumped to game (or beyond) himself.
       return passOnly("Respecting partner's signoff");
     }
@@ -2927,6 +2939,30 @@ List<SaycRule> _responderRebidAfterSuitRules(
     }
     // Jump rebid, 16-18.
     if (rebid.count >= 4) {
+      if (!oMajor && rebid.count == 4) {
+        // Opener's double jump to four of the minor shows 19+ and forces
+        // to game: bid our own self-sufficient major, else raise.
+        return [
+          SaycRule(
+            BidAction.contract(4, mySuit),
+            BidMeaning(
+              description: "Game in our self-sufficient major over the forcing raise",
+              suitLengths: {mySuit: const Range(low: 6)},
+            ),
+            ignoreInfo: true,
+            require: (h) =>
+                myMajor &&
+                h.count(mySuit) >= 6 &&
+                h.topHonorCount(mySuit) >= 2,
+          ),
+          SaycRule(
+            BidAction.contract(5, oSuit),
+            BidMeaning(
+                description: "Raising the game-forcing rebid to game"),
+            ignoreInfo: true,
+          ),
+        ];
+      }
       return passOnly("Respecting partner's game decision");
     }
     return [

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -1210,9 +1210,10 @@ List<SaycRule>? openerRebidRules(BidAction opening, BidAction response,
   return null;
 }
 
-List<SaycRule>? oneNtRebidRules(BidAction response) {
+List<SaycRule>? oneNtRebidRules(BidAction response,
+    {Range ntRange = const Range(low: 15, high: 17)}) {
   if (response == BidAction.contract(4, Suit.clubs)) {
-    return gerberAnswerRules(const Range(low: 15, high: 17));
+    return gerberAnswerRules(ntRange);
   }
   if (response == BidAction.contract(2, Suit.clubs)) {
     // Stayman.
@@ -1221,7 +1222,7 @@ List<SaycRule>? oneNtRebidRules(BidAction response) {
         BidAction.contract(2, Suit.hearts),
         BidMeaning(
           description: "4 hearts (may also hold 4 spades)",
-          hcp: const Range(low: 15, high: 17),
+          hcp: ntRange,
           suitLengths: {Suit.hearts: const Range(low: 4, high: 5)},
         ),
       ),
@@ -1229,7 +1230,7 @@ List<SaycRule>? oneNtRebidRules(BidAction response) {
         BidAction.contract(2, Suit.spades),
         BidMeaning(
           description: "4 spades, fewer than 4 hearts",
-          hcp: const Range(low: 15, high: 17),
+          hcp: ntRange,
           suitLengths: {
             Suit.spades: const Range(low: 4, high: 5),
             Suit.hearts: const Range(high: 3),
@@ -1240,7 +1241,7 @@ List<SaycRule>? oneNtRebidRules(BidAction response) {
         BidAction.contract(2, Suit.diamonds),
         BidMeaning(
           description: "Denies a 4-card major",
-          hcp: const Range(low: 15, high: 17),
+          hcp: ntRange,
           artificial: true,
           suitLengths: {
             Suit.spades: const Range(high: 3),
@@ -1269,18 +1270,19 @@ List<SaycRule>? oneNtRebidRules(BidAction response) {
     ];
   }
   if (response == BidAction.noTrump(2)) {
+    // Accept with the top two points of the range, decline below.
     return [
       SaycRule(
         BidAction.noTrump(3),
         BidMeaning(
             description: "Accepting the invitation",
-            hcp: const Range(low: 16, high: 17)),
+            hcp: Range(low: ntRange.high! - 1, high: ntRange.high)),
       ),
       SaycRule(
         BidAction.pass(),
         BidMeaning(
             description: "Declining the invitation",
-            hcp: const Range(low: 15, high: 15)),
+            hcp: Range(low: ntRange.low, high: ntRange.high! - 2)),
       ),
     ];
   }
@@ -1290,13 +1292,13 @@ List<SaycRule>? oneNtRebidRules(BidAction response) {
         BidAction.noTrump(6),
         BidMeaning(
             description: "Accepting the slam invitation",
-            hcp: const Range(low: 17, high: 17)),
+            hcp: Range(low: ntRange.high, high: ntRange.high)),
       ),
       SaycRule(
         BidAction.pass(),
         BidMeaning(
             description: "Declining the slam invitation",
-            hcp: const Range(low: 15, high: 16)),
+            hcp: Range(low: ntRange.low, high: ntRange.high! - 1)),
       ),
     ];
   }
@@ -5157,15 +5159,42 @@ SaycBid fallbackBid(List<PlayingCard> hand, List<BidAction> calls) {
       return result(BidAction.pass(), "Fallback: game already reached; passing");
     }
     if (combined >= 25) {
+      // Game in a minor needs eleven tricks: prefer nine in notrump unless
+      // clearly strong (28+ combined) with an unbalanced hand.
+      SaycBid? minorGame(Suit minor) {
+        if (combined >= 28 &&
+            !analysis.isBalanced &&
+            cheapestLevel(minor, lastBid) <= 5) {
+          return result(BidAction.contract(5, minor),
+              "Fallback: bidding game in our minor fit");
+        }
+        if (cheapestLevel(null, lastBid) <= 3) {
+          return result(BidAction.noTrump(3),
+              "Fallback: 3NT over game in a minor");
+        }
+        if (combined >= 28 && cheapestLevel(minor, lastBid) <= 5) {
+          return result(BidAction.contract(5, minor),
+              "Fallback: bidding game in our minor fit");
+        }
+        return null;
+      }
+
       if (lastBid.trump != null && analysis.count(lastBid.trump!) >= 4) {
-        return result(
-            BidAction.contract(gameLevel(lastBid.trump), lastBid.trump!),
-            "Fallback: raising to game (25+ combined points, 4+ support)");
+        if (_isMajor(lastBid.trump!)) {
+          return result(BidAction.contract(4, lastBid.trump!),
+              "Fallback: raising to game (25+ combined points, 4+ support)");
+        }
+        final g = minorGame(lastBid.trump!);
+        if (g != null) return g;
       }
       final fit = findBestFit();
       if (fit != null && cheapestLevel(fit, lastBid) <= gameLevel(fit)) {
-        return result(BidAction.contract(gameLevel(fit), fit),
-            "Fallback: bidding game in our known fit");
+        if (_isMajor(fit)) {
+          return result(BidAction.contract(4, fit),
+              "Fallback: bidding game in our known fit");
+        }
+        final g = minorGame(fit);
+        if (g != null) return g;
       }
       if (cheapestLevel(null, lastBid) <= 3) {
         return result(BidAction.noTrump(3),
@@ -5363,7 +5392,22 @@ List<SaycRule>? saycRulesForAuction(List<BidAction> calls) {
         }
       }
       if (last != null && last == partnerActions[0].contractBid) {
-        return oneNtRebidRules(partnerActions[0]);
+        // A direct 1NT overcall shows 15-18; a balancing one (after two
+        // passes) only 11-16. The continuation rules match on that range.
+        int myNtIndex = -1;
+        for (int i = 0; i < n; i++) {
+          if ((n - i) % 4 == 0 && calls[i] == BidAction.noTrump(1)) {
+            myNtIndex = i;
+            break;
+          }
+        }
+        final balancing = myNtIndex >= 2 &&
+            calls[myNtIndex - 1].bidType == BidType.pass &&
+            calls[myNtIndex - 2].bidType == BidType.pass;
+        return oneNtRebidRules(partnerActions[0],
+            ntRange: balancing
+                ? const Range(low: 11, high: 16)
+                : const Range(low: 15, high: 18));
       }
     }
     if (myActions.length == 1 &&
@@ -5516,10 +5560,12 @@ SaycBid selectSaycBid(List<PlayingCard> hand, List<BidAction> history,
   for (final rule in rules) {
     if (rule.matches(analysis)) return SaycBid(rule.action, rule.meaning);
   }
+  // A rule set exists for this auction but none of its rules fit the hand
+  // (a coverage hole, e.g. a hand too strong for every listed response).
+  // Let the heuristic fallback bidder act rather than passing blindly.
+  final fb = fallbackBid(hand, history);
   return SaycBid(
-    BidAction.pass(),
-    BidMeaning(description: "No rule matched; passing by default"),
-  );
+      fb.action, BidMeaning(description: "No rule matched; ${fb.meaning.description}"));
 }
 
 /// What `call` would show in this auction, independent of any hand. Returns

--- a/lib/bridge/sayc/selfplay.dart
+++ b/lib/bridge/sayc/selfplay.dart
@@ -173,16 +173,22 @@ void _lintResult(List<List<PlayingCard>> hands, List<BidAction> history,
           "contract $contract with only $trumps combined trumps"));
     }
   }
-  BidAction? firstBid;
-  for (int i = 0; i < history.length; i++) {
-    if (i % 2 == side && history[i].bidType == BidType.contract) {
-      firstBid = history[i];
-      break;
-    }
-  }
+  final sideBids = [
+    for (int i = 0; i < history.length; i++)
+      if (i % 2 == side && history[i].bidType == BidType.contract)
+        history[i].contractBid!
+  ];
+  final firstBid = sideBids.isEmpty ? null : sideBids.first;
+  // A double-jump raise of the side's first suit (e.g. 1S-4S) is a
+  // preemptive raise, not a strength-showing auction.
+  final jumpRaised = firstBid != null &&
+      sideBids.skip(1).any((b) =>
+          b.trump != null &&
+          b.trump == firstBid.trump &&
+          b.count >= firstBid.count + 3);
   final preempted = firstBid != null &&
-      firstBid.contractBid!.trump != null &&
-      firstBid.contractBid!.count >= 2;
+      firstBid.trump != null &&
+      (firstBid.count >= 2 || jumpRaised);
   final atGame = contract.count >= _gameLevel(trump);
   if (atGame && !doubled && !preempted && combinedTotal(side) < 24) {
     findings.add(SelfPlayFinding(

--- a/lib/bridge/sayc/selfplay.dart
+++ b/lib/bridge/sayc/selfplay.dart
@@ -237,6 +237,13 @@ SelfPlayResult runDeal(List<List<PlayingCard>> hands) {
     if (meaning != null) {
       _lintAdvertisement(
           HandAnalysis(hands[seat]), seat, call, meaning, history, findings);
+      // Not a failure, but worth monitoring: a rule set existed for this
+      // auction but no rule matched the hand, so the fallback bidder acted.
+      if (meaning.description.startsWith("No rule matched")) {
+        findings.add(SelfPlayFinding("no-rule-matched",
+            "seat $seat (${HandAnalysis(hands[seat]).totalPoints} points) "
+            "chose $call after '${_fmt(history)}'"));
+      }
     }
     history.add(call);
     if (history.length >= _maxCalls) {

--- a/lib/bridge/sayc/selfplay.dart
+++ b/lib/bridge/sayc/selfplay.dart
@@ -250,6 +250,14 @@ SelfPlayResult runDeal(List<List<PlayingCard>> hands) {
             "seat $seat (${HandAnalysis(hands[seat]).totalPoints} points) "
             "chose $call after '${_fmt(history)}'"));
       }
+      // Also monitored: auctions with no rule set at all, where the
+      // heuristic fallback acts and the call carries no meaning for
+      // partner's or opponents' inference.
+      if (meaning.description.startsWith("Fallback:") &&
+          call.bidType != BidType.pass) {
+        findings.add(SelfPlayFinding("fallback-used",
+            "seat $seat chose $call after '${_fmt(history)}'"));
+      }
     }
     history.add(call);
     if (history.length >= _maxCalls) {

--- a/lib/bridge/sayc/selfplay.dart
+++ b/lib/bridge/sayc/selfplay.dart
@@ -7,6 +7,8 @@
 ///   illegal-call     the chosen call is not legal in the auction
 ///   runaway-auction  the auction did not terminate
 ///   under-advertised the hand is below the minimums its own bid advertises
+///   over-advertised  the hand exceeds the maximums its own bid advertises
+///                    (partner may pass a hand that wanted to force on)
 ///
 /// Heuristic result-quality flags (judgment, not necessarily bugs):
 ///   thin-game        non-preemptive game with < 24 combined total points
@@ -27,6 +29,7 @@ const hardFailureCategories = {
   "illegal-call",
   "runaway-auction",
   "under-advertised",
+  "over-advertised",
 };
 
 const _maxCalls = 40;
@@ -106,6 +109,28 @@ void _lintAdvertisement(HandAnalysis hand, int seat, BidAction call,
         "under-advertised",
         "seat $seat bid $call after '${_fmt(history)}': "
         "${problems.join('; ')} [${meaning.description}]"));
+  }
+
+  final over = <String>[];
+  final hcpHigh = meaning.hcp?.high;
+  if (hcpHigh != null && hand.hcp > hcpHigh) {
+    over.add("shows at most $hcpHigh HCP, has ${hand.hcp}");
+  }
+  final totalHigh = meaning.totalPoints?.high;
+  if (totalHigh != null && hand.totalPoints > totalHigh) {
+    over.add("shows at most $totalHigh total points, has ${hand.totalPoints}");
+  }
+  for (final suit in Suit.values) {
+    final high = meaning.suitLengths[suit]?.high;
+    if (high != null && hand.count(suit) > high) {
+      over.add("shows at most $high ${suit.name}, has ${hand.count(suit)}");
+    }
+  }
+  if (over.isNotEmpty) {
+    findings.add(SelfPlayFinding(
+        "over-advertised",
+        "seat $seat bid $call after '${_fmt(history)}': "
+        "${over.join('; ')} [${meaning.description}]"));
   }
 }
 

--- a/scripts/bidding_audit.dart
+++ b/scripts/bidding_audit.dart
@@ -1,0 +1,48 @@
+/// Runs self-play auctions over many random deals and reports findings
+/// grouped by category and rule, for auditing bidding-rule consistency
+/// (e.g. rules whose hand requirements don't match their advertised
+/// meaning ranges).
+///
+///   dart run scripts/bidding_audit.dart [--deals N] [--seed N] [--category X]
+library;
+
+import 'package:cards_with_cats/bridge/sayc/selfplay.dart';
+
+void main(List<String> args) {
+  int deals = 2000;
+  int seed = 1;
+  String? category;
+  for (int i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--deals":
+        deals = int.parse(args[++i]);
+      case "--seed":
+        seed = int.parse(args[++i]);
+      case "--category":
+        category = args[++i];
+    }
+  }
+  final counts = <String, int>{};
+  final examples = <String, List<String>>{};
+  for (int i = 0; i < deals; i++) {
+    final result = runDeal(dealHands(seed, i));
+    for (final f in result.findings) {
+      if (category != null && f.category != category) continue;
+      // Group by category plus the rule description in trailing brackets.
+      final m = RegExp(r"\[(.*)\]$").firstMatch(f.message);
+      final key = "${f.category}: ${m?.group(1) ?? f.message}";
+      counts[key] = (counts[key] ?? 0) + 1;
+      (examples[key] ??= []).add("deal $i: ${f.message}");
+    }
+  }
+  final keys = counts.keys.toList()
+    ..sort((a, b) => counts[b]!.compareTo(counts[a]!));
+  for (final k in keys) {
+    print("${counts[k]!.toString().padLeft(5)}  $k");
+    for (final e in examples[k]!.take(2)) {
+      print("       $e");
+    }
+  }
+  print("\ntotal: ${counts.values.fold(0, (a, b) => a + b)} findings "
+      "over $deals deals");
+}

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1144,6 +1144,43 @@ void main() {
           "2C");
     });
 
+    test("three-level second suits show 15+", () {
+      // 21 total: show the second suit over the two-level response
+      // instead of hiding in the unlimited catch-all rebid (deal 1307).
+      expect(
+          openingBid("AQJ74", "98", "AK", "AQ76",
+              history: ["1S", "pass", "2D", "pass"]),
+          "3C");
+      // Responder treats it as strong and chooses game.
+      expect(
+          openingBid("9", "KJ76", "Q8543", "K52",
+              history: ["1S", "pass", "2D", "pass", "3C", "pass"]),
+          "3NT");
+      // High reverse in competition (deal 2170).
+      expect(
+          openingBid("A6", "AQ32", "A3", "AKT83",
+              history: ["1C", "2H", "2S", "pass"]),
+          "3H");
+      // A minimum still lacks the strength for the three level.
+      expect(
+          openingBid("AQJ74", "98", "A2", "Q876",
+              history: ["1S", "pass", "2D", "pass"]),
+          "2S");
+    });
+
+    test("negative doubler continues over opener's rebids", () {
+      // Opener's jump shows 16+: drive to game with 10+ (deal 1093).
+      expect(
+          openingBid("98", "QT53", "AKJT", "KJT",
+              history: ["1C", "1S", "X", "pass", "3C", "pass"]),
+          "5C");
+      // 13 with support but no stopper: invite (deal 2861).
+      expect(
+          openingBid("AKQ8", "KT873", "5", "T64",
+              history: ["1C", "2D", "X", "pass", "3C", "pass"]),
+          "4C");
+    });
+
     test("doubler bids on over the advance with a big hand", () {
       // 24 total (22 HCP): 3NT with their suit stopped (deal 1021).
       expect(

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1256,9 +1256,15 @@ void main() {
 
     test("no invitational jump into game when advancing a high double", () {
       final h = ["1D", "3C", "pass", "pass", "X", "pass"];
-      // 11 total points: a "jump" over a three-level double would commit to
-      // game, so just bid the suit.
-      expect(openingBid("AJ4", "AJ432", "432", "32", history: h), "3H");
+      final history = h.map(BidAction.fromString).toList();
+      // With no jump available below game, the cheap advance covers all
+      // hands below game-forcing strength, with a range that says so.
+      final weak = selectSaycBid(hand("AJ4", "J5432", "432", "32"), history);
+      expect(weak.action.toString(), "3H"); // 6 total
+      expect(weak.meaning.totalPoints, const Range(high: 11));
+      final invite = selectSaycBid(hand("AJ4", "AJ432", "432", "32"), history);
+      expect(invite.action.toString(), "3H"); // 11 total
+      expect(invite.meaning.totalPoints, const Range(high: 11));
       // With real game values, bid it.
       expect(openingBid("AJ4", "AKJ32", "432", "32", history: h), "4H");
     });

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -343,6 +343,29 @@ void main() {
     });
   });
 
+  group("preemptive major raises", () {
+    test("jump to game with 5+ trumps and less than Jacoby strength", () {
+      // 6 total points: preempt.
+      expect(openingBid("QT932", "32", "K432", "32", history: ["1S", "pass"]),
+          "4S");
+      // 11 total: still the preemptive raise, not a limit raise — with a
+      // ten-card fit the partnership belongs in game.
+      expect(openingBid("KT932", "32", "KQ42", "Q2", history: ["1S", "pass"]),
+          "4S");
+      // 12 with a singleton still splinters; 13+ still goes through
+      // Jacoby 2NT.
+      expect(openingBid("KT932", "2", "KQJ2", "Q32", history: ["1S", "pass"]),
+          "4H");
+      expect(openingBid("KT932", "A2", "KQ42", "Q2", history: ["1S", "pass"]),
+          "2NT");
+      // Only four trumps: the normal single raise.
+      expect(openingBid("T932", "A32", "Q432", "32", history: ["1S", "pass"]),
+          "2S");
+      expect(openingBid("32", "QT932", "K432", "32", history: ["1H", "pass"]),
+          "4H");
+    });
+  });
+
   group("responses to minor openings", () {
     test("four-four majors up the line", () {
       expect(openingBid("K432", "A432", "32", "Q32", history: ["1C", "pass"]),

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -656,6 +656,25 @@ void main() {
           "3D"); // 17 total
     });
 
+    test("game rebid after 1NT response with self-sufficient major", () {
+      // 21 HCP + 2 length points: the invitational 3S could be passed.
+      expect(
+          openingBid("KQJT76", "AQT", "QT", "AK",
+              history: ["1S", "pass", "1NT", "pass"]),
+          "4S");
+      // 17 total still invites.
+      expect(
+          openingBid("KQJT42", "K2", "Q54", "A2",
+              history: ["1S", "pass", "1NT", "pass"]),
+          "3S");
+      // Responder respects the game rebid instead of "accepting" 4H
+      // with an illegal second 4H.
+      expect(
+          openingBid("Q32", "K2", "Q432", "J432",
+              history: ["1H", "pass", "1NT", "pass", "4H", "pass"]),
+          "Pass");
+    });
+
     test("game rebid with self-sufficient major and 19+", () {
       // 20 HCP + 3 length points: too strong for the invitational single
       // jump, which partner may pass.

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1194,6 +1194,15 @@ void main() {
       expect(openingBid("KQ32", "K32", "AQ432", "2", history: h), "Pass");
     });
 
+    test("high reopening double needs support for the unbid majors", () {
+      final h = ["1D", "3C", "pass", "pass"];
+      // A double would force partner to the three level, and with 4-2 in
+      // the majors there is no safe landing spot.
+      expect(openingBid("AK32", "52", "QT987", "K2", history: h), "Pass");
+      // With both majors, reopen.
+      expect(openingBid("AK32", "K53", "QT987", "2", history: h), "Double");
+    });
+
     test("sandwich seat", () {
       expect(openingBid("KQ32", "2", "AJ32", "K432", history: ["1H", "pass", "2H"]),
           "Double");
@@ -1243,6 +1252,15 @@ void main() {
       final h = ["1D", "1S", "pass", "pass", "X", "pass"];
       expect(openingBid("AKJ32", "432", "32", "432", history: h), "Pass");
       expect(openingBid("432", "K432", "Q32", "432", history: h), "2H");
+    });
+
+    test("no invitational jump into game when advancing a high double", () {
+      final h = ["1D", "3C", "pass", "pass", "X", "pass"];
+      // 11 total points: a "jump" over a three-level double would commit to
+      // game, so just bid the suit.
+      expect(openingBid("AJ4", "AJ432", "432", "32", history: h), "3H");
+      // With real game values, bid it.
+      expect(openingBid("AJ4", "AKJ32", "432", "32", history: h), "4H");
     });
   });
 

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -679,6 +679,24 @@ void main() {
           "3D"); // 17 total
     });
 
+    test("the game-forcing 4m rebid is not passed", () {
+      // Weak responder raises to game.
+      expect(
+          openingBid("J87643", "T92", "T4", "53",
+              history: ["1C", "pass", "1S", "pass", "4C", "pass"]),
+          "5C");
+      // With a self-sufficient major, game there instead.
+      expect(
+          openingBid("KQJ876", "T92", "T4", "53",
+              history: ["1C", "pass", "1S", "pass", "4C", "pass"]),
+          "4S");
+      // Same after a 1NT response, where there is no suit to return to.
+      expect(
+          openingBid("Q32", "Q32", "32", "QJ432",
+              history: ["1D", "pass", "1NT", "pass", "4D", "pass"]),
+          "5D");
+    });
+
     test("strong rebids with a long minor", () {
       // 19+ with the unbid suits stopped: gamble 3NT.
       expect(

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1313,6 +1313,27 @@ void main() {
   });
 
   group("fallback bidder", () {
+    test("acts when a rule set exists but nothing matches", () {
+      // 19 HCP balanced responder: too strong for every response rule
+      // (2NT shows 13-15, 3NT 16-18); previously passed partner's opening.
+      expect(openingBid("Q98", "K64", "AKQ", "KQT9", history: ["1C", "pass"]),
+          "3NT");
+      // With a minor fit and game values but under 28 combined, the
+      // fallback prefers 3NT over five of the minor.
+      expect(openingBid("JT9", "A2", "JT6", "KQJ83", history: ["1C", "pass"]),
+          "3NT");
+    });
+
+    test("balancing 1NT continuations use the lighter range", () {
+      final stayman = ["1C", "pass", "pass", "1NT", "pass", "2C", "pass"];
+      expect(openingBid("KJ3", "K643", "543", "AJT", history: stayman), "2H");
+      final invite = ["1H", "pass", "pass", "1NT", "pass", "2NT", "pass"];
+      expect(openingBid("K432", "KJ2", "QJ2", "Q32", history: invite),
+          "Pass"); // 12 HCP: bottom of 11-16
+      expect(openingBid("AQ32", "KJ2", "KJ2", "Q32", history: invite),
+          "3NT"); // 16 HCP: top of the range accepts
+    });
+
     test("passes when game is reached", () {
       final result = selectSaycBid(
           hand("A432", "QJ32", "QJ2", "32"),

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -656,6 +656,29 @@ void main() {
           "3D"); // 17 total
     });
 
+    test("strong rebids with a long minor", () {
+      // 19+ with the unbid suits stopped: gamble 3NT.
+      expect(
+          openingBid("A2", "K2", "AK2", "AQJ432",
+              history: ["1C", "pass", "1H", "pass"]),
+          "3NT");
+      // 19+ without a spade stopper: force with a jump to four.
+      expect(
+          openingBid("32", "A2", "AK2", "KQJT65",
+              history: ["1C", "pass", "1H", "pass"]),
+          "4C");
+      // Same after a 1NT response.
+      expect(
+          openingBid("A2", "K2", "AQJT42", "K32",
+              history: ["1D", "pass", "1NT", "pass"]),
+          "3NT");
+      // 16-18 still makes the invitational jump.
+      expect(
+          openingBid("32", "K2", "A32", "AKJ432",
+              history: ["1C", "pass", "1H", "pass"]),
+          "3C");
+    });
+
     test("game rebid after 1NT response with self-sufficient major", () {
       // 21 HCP + 2 length points: the invitational 3S could be passed.
       expect(
@@ -1360,7 +1383,9 @@ void main() {
       expect(nt, contains("balanced"));
       final spade = describeSaycCall([], BidAction.fromString("1S"))!.summary();
       expect(spade, contains("5+ spades"));
-      expect(spade, contains("13-21 total points"));
+      // 13+ total points with the ceiling expressed in HCP (the 2C boundary).
+      expect(spade, contains("13+ total points"));
+      expect(spade, contains("<=21 HCP"));
       final weakTwo = describeSaycCall([], BidAction.fromString("2S"))!.summary();
       expect(weakTwo, contains("6 spades"));
       expect(weakTwo, contains("5-10 HCP"));
@@ -1878,7 +1903,8 @@ void main() {
       expect(ex.calls[0].meaning!.totalPoints, const Range(high: 12));
       expect(ex.calls[1].meaning!.suitLengths[Suit.spades],
           const Range(low: 5));
-      expect(ex.players[1]!.totalPoints, const Range(low: 13, high: 21));
+      expect(ex.players[1]!.totalPoints, const Range(low: 13));
+      expect(ex.players[1]!.hcp, const Range(high: 21));
     });
   });
 }

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1144,6 +1144,62 @@ void main() {
           "2C");
     });
 
+    test("doubler bids on over the advance with a big hand", () {
+      // 24 total (22 HCP): 3NT with their suit stopped (deal 1021).
+      expect(
+          openingBid("QJ9", "AQ", "AJ", "AKJ932",
+              history: ["1D", "pass", "pass", "X", "pass", "1H", "pass"]),
+          "3NT");
+      // 21 with a solid 8-card suit: game in it (deal 1615).
+      expect(
+          openingBid("AKQJT843", "4", "A", "K72",
+              history: ["1D", "pass", "pass", "X", "pass", "1H", "pass"]),
+          "4S");
+      // 22 with support: raise the forced 4D advance to game (deal 1539).
+      expect(
+          openingBid("A8", "KQJ82", "KJ7", "AK7",
+              history: ["3S", "pass", "pass", "X", "pass", "4D", "pass"]),
+          "5D");
+      // 20 with a self-sufficient suit after the opponents raised (deal 47).
+      expect(
+          openingBid("AKQJ42", "6", "AQ43", "QT",
+              history: ["2H", "X", "3H", "4D", "pass"]),
+          "4S");
+      // 26: accept partner's invitational jump advance (deal 890).
+      expect(
+          openingBid("AQ962", "AQ2", "AK", "AQ6",
+              history: ["pass", "pass", "2H", "X", "pass", "4C", "pass"]),
+          "5C");
+      // A minimum double passes the forced advance.
+      expect(
+          openingBid("A432", "2", "KQ32", "Q432",
+              history: ["1H", "pass", "pass", "X", "pass", "1S", "pass"]),
+          "Pass");
+    });
+
+    test("overcaller rebids over the advance in a new suit", () {
+      // Maximum with a self-sufficient suit: game in it (deal 1134).
+      expect(
+          openingBid("AKQT982", "4", "6", "Q874",
+              history: ["1C", "1S", "pass", "2H", "pass"]),
+          "4S");
+      // Forcing 3-level advance: raise with a doubleton (deal 2338).
+      expect(
+          openingBid("JT", "62", "Q93", "AKJ632",
+              history: ["2D", "3C", "pass", "3S", "pass"]),
+          "4S");
+      // Forcing minor advance: 3NT with their suit stopped (deal 120).
+      expect(
+          openingBid("9854", "KJ2", "AJT82", "A",
+              history: ["1H", "2D", "pass", "3C", "pass"]),
+          "3NT");
+      // Two-level advance may be passed with a misfit minimum (deal 2451).
+      expect(
+          openingBid("J32", "7", "A654", "KQJ84",
+              history: ["1S", "2C", "pass", "2H", "pass"]),
+          "Pass");
+    });
+
     test("doubler rescues when their redouble is passed back around", () {
       // Advancer's pass over the redouble asks the doubler to pick a suit;
       // passing again would let the opponents play 1S redoubled.

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1312,17 +1312,35 @@ void main() {
     });
   });
 
-  group("fallback bidder", () {
-    test("acts when a rule set exists but nothing matches", () {
-      // 19 HCP balanced responder: too strong for every response rule
-      // (2NT shows 13-15, 3NT 16-18); previously passed partner's opening.
-      expect(openingBid("Q98", "K64", "AKQ", "KQT9", history: ["1C", "pass"]),
-          "3NT");
-      // With a minor fit and game values but under 28 combined, the
-      // fallback prefers 3NT over five of the minor.
-      expect(openingBid("JT9", "A2", "JT6", "KQJ83", history: ["1C", "pass"]),
-          "3NT");
+  group("response rule coverage", () {
+    test("19+ balanced over a minor bids 3NT", () {
+      final strong = selectSaycBid(hand("Q98", "K64", "AKQ", "KQT9"),
+          ["1C", "pass"].map(BidAction.fromString).toList());
+      expect(strong.action.toString(), "3NT");
+      expect(strong.meaning.hcp, const Range(low: 16));
     });
+
+    test("12 HCP with a length point makes the limit raise", () {
+      expect(openingBid("JT9", "A2", "JT6", "KQJ83", history: ["1C", "pass"]),
+          "3C");
+      expect(openingBid("K6", "A98", "AJT83", "763", history: ["1D", "pass"]),
+          "3D");
+      // 13 HCP balanced with support still prefers 2NT.
+      expect(openingBid("J98", "K64", "A32", "KQT9", history: ["1C", "pass"]),
+          "2NT");
+    });
+
+    test("flat game-force with 3-card support bids 2C on three", () {
+      final short2c = selectSaycBid(hand("953", "QJ87", "KJ4", "AQ4"),
+          ["1S", "pass"].map(BidAction.fromString).toList());
+      expect(short2c.action.toString(), "2C");
+      expect(short2c.meaning.suitLengths[Suit.clubs], const Range(low: 3));
+      expect(openingBid("J92", "A542", "A84", "A87", history: ["1S", "pass"]),
+          "2C");
+    });
+  });
+
+  group("fallback bidder", () {
 
     test("balancing 1NT continuations use the lighter range", () {
       final stayman = ["1C", "pass", "pass", "1NT", "pass", "2C", "pass"];


### PR DESCRIPTION
- Switches to using fallback when a bidding history has rules but none of them apply. Previously it always passed which was sometimes very wrong.
- Adds detection of bids that understate actual strength in `selfplay.dart`.
- Fixes several underbidding issues (e.g. non-forcing jump-rebids with 20 points, passing after making a "takeout" double with 17+ points).
- Adds preemptive major raises: 1S-4S shows 6-12 points and 5+ trumps.
- Avoids reopening doubles without support for majors.