### PR TITLE
More bidding fixes, and instrumentation to analyze precision/recall of makable games and slams

### DIFF
--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -3959,6 +3959,20 @@ List<SaycRule> interferenceResponseRules(
       ),
     ));
   }
+  if (cheapest == 3 && isMajor) {
+    // Over a jump overcall, compete to the three level on the nine-card
+    // fit even with a weak hand; this takes priority over a negative
+    // double when holding four trumps.
+    raiseRules.add(SaycRule(
+      BidAction.contract(3, suit),
+      BidMeaning(
+        description:
+            "Competitive raise over the jump overcall: 4+ $name, 6-10 points",
+        totalPoints: const Range(low: 6, high: 10),
+        suitLengths: {suit: const Range(low: 4)},
+      ),
+    ));
+  }
   if (isMajor) {
     raiseRules.add(SaycRule(
       BidAction.contract(4, suit),

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -5426,7 +5426,7 @@ List<SaycRule> competitiveRebidRules(ContractBid opening, BidAction rhoAction,
           suitLengths: {oSuit: const Range(low: 4)},
         ),
         ignoreInfo: true,
-        require: (h) => h.count(oSuit) >= 4,
+        require: (h) => h.count(oSuit) >= 4 && h.totalPoints <= 10,
       ));
     }
   } else if (myBid != null && myBid.trump != null) {
@@ -5465,9 +5465,96 @@ List<SaycRule> competitiveRebidRules(ContractBid opening, BidAction rhoAction,
       }
     }
   }
+  // Value-showing actions: with an opener opposite, 11+ must not sell out
+  // to a low contract.
+  final enemySuits = <Suit>{
+    if (rhoAction.bidType == BidType.contract &&
+        rhoAction.contractBid!.trump != null)
+      rhoAction.contractBid!.trump!,
+    if (lastBid.trump != null) lastBid.trump!,
+  };
+  final ntLevel = cheapestLevel(null, lastBid);
+  if (ntLevel <= 3) {
+    rules.add(SaycRule(
+      BidAction.noTrump(3),
+      BidMeaning(
+          description: "Game in notrump: 13+ with their suit stopped",
+          totalPoints: const Range(low: 13)),
+      ignoreInfo: true,
+      require: (h) => h.totalPoints >= 13 && enemySuits.every(h.hasStopper),
+    ));
+  }
+  if (ntLevel <= 2) {
+    rules.add(SaycRule(
+      BidAction.noTrump(ntLevel),
+      BidMeaning(
+          description: "Natural: 11-12 with their suit stopped",
+          totalPoints: const Range(low: 11, high: 12)),
+      ignoreInfo: true,
+      require: (h) =>
+          h.totalPoints >= 11 &&
+          h.totalPoints <= 12 &&
+          enemySuits.every(h.hasStopper),
+    ));
+  }
+  rules.add(SaycRule(
+    BidAction.double(),
+    BidMeaning(
+        description: "Action double: 11+, no clear bid "
+            "(partner may pass for penalty)",
+        totalPoints: const Range(low: 11)),
+    ignoreInfo: true,
+    require: (h) => h.totalPoints >= 11,
+  ));
   rules.add(SaycRule(BidAction.pass(),
       BidMeaning(description: "Nothing more to say; defending")));
   return rules;
+}
+
+/// Opener's choice after passing the overcall and hearing partner's
+/// action double: convert to penalties with trump length, else pull to
+/// the cheapest fit.
+List<SaycRule> actionDoubleAdvanceRules(
+    ContractBid opening, ContractBid response, ContractBid theirBid) {
+  final theirSuit = theirBid.trump!;
+  final oSuit = opening.trump!;
+  final rSuit = response.trump;
+  return [
+    SaycRule(
+      BidAction.pass(),
+      BidMeaning(
+          description:
+              "Converting the double to penalties with trump length",
+          suitLengths: {theirSuit: const Range(low: 2)}),
+      ignoreInfo: true,
+      require: (h) => h.count(theirSuit) >= 2,
+    ),
+    if (rSuit != null &&
+        rSuit != theirSuit &&
+        cheapestLevel(rSuit, theirBid) <= 3)
+      SaycRule(
+        BidAction.contract(cheapestLevel(rSuit, theirBid), rSuit),
+        BidMeaning(
+          description: "Pulling the double: 3+ ${_suitNames[rSuit]}",
+          suitLengths: {rSuit: const Range(low: 3)},
+        ),
+        ignoreInfo: true,
+        require: (h) => h.count(rSuit) >= 3,
+      ),
+    if (cheapestLevel(oSuit, theirBid) <= 3)
+      SaycRule(
+        BidAction.contract(cheapestLevel(oSuit, theirBid), oSuit),
+        BidMeaning(
+          description: "Pulling the double: rebidding ${_suitNames[oSuit]}",
+          suitLengths: {oSuit: const Range(low: 4)},
+        ),
+        ignoreInfo: true,
+        require: (h) => h.count(oSuit) >= 4,
+      ),
+    SaycRule(BidAction.pass(),
+        BidMeaning(description: "No better spot; defending"),
+        ignoreInfo: true),
+  ];
 }
 
 // ---------------------------------------------------------------------------
@@ -5949,6 +6036,19 @@ List<SaycRule>? saycRulesForAuction(List<BidAction> calls) {
   }
 
   // We opened.
+  if (n == first + 8 &&
+      isSuitBid(opening) &&
+      calls[first + 2].bidType == BidType.contract &&
+      isSuitBid(calls[first + 3]) &&
+      calls[first + 4].bidType == BidType.pass &&
+      calls[first + 5].bidType == BidType.pass &&
+      calls[first + 6].bidType == BidType.double &&
+      calls[first + 7].bidType == BidType.pass) {
+    // Partner responded, they overcalled, we and RHO passed, and partner
+    // doubled: choose between penalties and the cheapest fit.
+    return actionDoubleAdvanceRules(opening.contractBid!,
+        calls[first + 2].contractBid!, calls[first + 3].contractBid!);
+  }
   if (oppActions.isEmpty) {
     if (n == first + 4) {
       return openerRebidRules(opening, calls[first + 2]);

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -2056,6 +2056,14 @@ List<SaycRule>? responderRebidRules(
       }
       rules.addAll([
         SaycRule(
+          BidAction.noTrump(6),
+          BidMeaning(
+              description: "Slam: 13+ opposite the 2NT opening",
+              hcp: const Range(low: 13)),
+          ignoreInfo: true,
+          require: (h) => h.hcp >= 13,
+        ),
+        SaycRule(
           BidAction.noTrump(4),
           BidMeaning(
               description: "Quantitative: invites 6NT, no fit",
@@ -2089,18 +2097,38 @@ List<SaycRule>? responderRebidRules(
           BidAction.contract(4, major),
           BidMeaning(
             description: "To play: 6+ $name, game values",
-            hcp: const Range(low: 5),
+            hcp: const Range(low: 5, high: 10),
             suitLengths: {major: const Range(low: 6)},
           ),
           ignoreInfo: true,
-          require: (h) => h.count(major) >= 6,
+          require: (h) => h.count(major) >= 6 && h.hcp <= 10,
+        ),
+        SaycRule(
+          BidAction.noTrump(6),
+          BidMeaning(
+            description: "Slam: 13+ with 5+ $name",
+            hcp: const Range(low: 13),
+            suitLengths: {major: const Range(low: 5)},
+          ),
+          ignoreInfo: true,
+          require: (h) => h.hcp >= 13,
+        ),
+        SaycRule(
+          BidAction.noTrump(4),
+          BidMeaning(
+            description: "Quantitative: invites slam with 5+ $name",
+            hcp: const Range(low: 11, high: 12),
+            suitLengths: {major: const Range(low: 5)},
+          ),
+          ignoreInfo: true,
+          require: (h) => h.hcp >= 11,
         ),
         SaycRule(
           BidAction.noTrump(3),
           BidMeaning(
             description:
                 "Choice of games: exactly 5 $name, opener corrects with a fit",
-            hcp: const Range(low: 5),
+            hcp: const Range(low: 5, high: 10),
             suitLengths: {major: const Range(low: 5, high: 5)},
           ),
           ignoreInfo: true,
@@ -2167,10 +2195,26 @@ List<SaycRule>? _responderRebidAfter1ntRules(
         require: (h) => h.hcp <= 9,
       ),
       SaycRule(
+        BidAction.noTrump(6),
+        BidMeaning(
+            description: "Slam: 18+ opposite the notrump opening",
+            hcp: const Range(low: 18)),
+        ignoreInfo: true,
+        require: (h) => h.hcp >= 18,
+      ),
+      SaycRule(
+        BidAction.noTrump(4),
+        BidMeaning(
+            description: "Quantitative: invites 6NT, no fit",
+            hcp: const Range(low: 16, high: 17)),
+        ignoreInfo: true,
+        require: (h) => h.hcp >= 16,
+      ),
+      SaycRule(
         BidAction.noTrump(3),
         BidMeaning(
             description: "To play, no major-suit fit",
-            hcp: const Range(low: 10)),
+            hcp: const Range(low: 10, high: 15)),
         ignoreInfo: true,
       ),
     ]);
@@ -2214,14 +2258,34 @@ List<SaycRule>? _responderRebidAfter1ntRules(
           suitLengths: {major: const Range(low: 6)},
         ),
         ignoreInfo: true,
-        require: (h) => h.count(major) >= 6,
+        require: (h) => h.count(major) >= 6 && h.hcp <= 15,
+      ),
+      SaycRule(
+        BidAction.noTrump(6),
+        BidMeaning(
+          description: "Slam: 18+ with 5+ $name",
+          hcp: const Range(low: 18),
+          suitLengths: {major: const Range(low: 5)},
+        ),
+        ignoreInfo: true,
+        require: (h) => h.hcp >= 18,
+      ),
+      SaycRule(
+        BidAction.noTrump(4),
+        BidMeaning(
+          description: "Quantitative: invites slam with 5+ $name",
+          hcp: const Range(low: 16, high: 17),
+          suitLengths: {major: const Range(low: 5)},
+        ),
+        ignoreInfo: true,
+        require: (h) => h.hcp >= 16,
       ),
       SaycRule(
         BidAction.noTrump(3),
         BidMeaning(
           description:
               "Choice of games: exactly 5 $name, opener corrects with a fit",
-          hcp: const Range(low: 10),
+          hcp: const Range(low: 10, high: 15),
           suitLengths: {major: const Range(low: 5, high: 5)},
         ),
         ignoreInfo: true,

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -4756,7 +4756,7 @@ List<SaycRule> reopeningRules(ContractBid opening, ContractBid overcall) {
             "Reopening takeout double: at most two $theirName"
             "${unbidMajors.isNotEmpty ? ', support for the unbid majors' : ''}"
             " (partner may pass for penalty)",
-        totalPoints: const Range(low: 13, high: 21),
+        totalPoints: const Range(low: 13),
         artificial: true,
         suitLengths: {
           theirSuit: const Range(high: 2),

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -5005,25 +5005,38 @@ List<SaycRule> negativeDoubleRebidRules(
   }
   final ntLevel = cheapestLevel(null, overcall);
   rules.addAll([
-    SaycRule(
-      BidAction.withBid(ContractBid(ntLevel + 1, null)),
-      BidMeaning(
-          description: "18-19 balanced with a stopper",
-          hcp: const Range(low: 18, high: 19),
-          balanced: true),
-      ignoreInfo: true,
-      require: (h) =>
-          h.isBalanced && h.hasStopper(overcallSuit) && h.hcp >= 18,
-    ),
-    SaycRule(
-      BidAction.withBid(ContractBid(ntLevel, null)),
-      BidMeaning(
-          description: "12-14 balanced with a stopper",
-          hcp: const Range(low: 12, high: 14),
-          balanced: true),
-      ignoreInfo: true,
-      require: (h) => h.isBalanced && h.hasStopper(overcallSuit),
-    ),
+    // Notrump rebids are level-aware: below game the cheapest notrump is
+    // a 12-14 minimum and the jump shows 18-19, but when the cheapest
+    // notrump is already 3NT it commits to game and needs a real hand.
+    if (ntLevel <= 2) ...[
+      SaycRule(
+        BidAction.withBid(ContractBid(ntLevel + 1, null)),
+        BidMeaning(
+            description: "18-19 balanced with a stopper",
+            hcp: const Range(low: 18, high: 19),
+            balanced: true),
+        ignoreInfo: true,
+        require: (h) =>
+            h.isBalanced && h.hasStopper(overcallSuit) && h.hcp >= 18,
+      ),
+      SaycRule(
+        BidAction.withBid(ContractBid(ntLevel, null)),
+        BidMeaning(
+            description: "12-14 balanced with a stopper",
+            hcp: const Range(low: 12, high: 14),
+            balanced: true),
+        ignoreInfo: true,
+        require: (h) => h.isBalanced && h.hasStopper(overcallSuit),
+      ),
+    ] else
+      SaycRule(
+        BidAction.noTrump(3),
+        BidMeaning(
+            description: "Game in notrump: 15+ with a stopper",
+            hcp: const Range(low: 15)),
+        ignoreInfo: true,
+        require: (h) => h.hcp >= 15 && h.hasStopper(overcallSuit),
+      ),
     SaycRule(
       BidAction.contract(cheapestLevel(mySuit, overcall), mySuit),
       BidMeaning(

--- a/lib/bridge/sayc/selfplay.dart
+++ b/lib/bridge/sayc/selfplay.dart
@@ -15,6 +15,8 @@
 ///   slam-light       undoubled slam with < 28 combined HCP
 ///   silly-strain     suit contract with <= 6 combined trumps
 ///   missed-game      declaring side with 26+ combined stopped below game
+///   missed-slam      declaring side with 33+ combined HCP (or 36+ total
+///                    points) stopped below the six level
 ///   passed-out       deal passed out despite 25+ combined points
 library;
 
@@ -205,6 +207,14 @@ void _lintResult(List<List<PlayingCard>> hands, List<BidAction> history,
         "missed-game",
         "the declaring side has ${combinedTotal(side)} combined points but "
         "stopped in $contract"));
+  }
+  if (contract.count < 6 &&
+      !doubled &&
+      (combinedHcp(side) >= 33 || combinedTotal(side) >= 36)) {
+    findings.add(SelfPlayFinding(
+        "missed-slam",
+        "the declaring side has ${combinedHcp(side)} combined HCP "
+        "(${combinedTotal(side)} total points) but stopped in $contract"));
   }
 }
 

--- a/scripts/bidding_accuracy.dart
+++ b/scripts/bidding_accuracy.dart
@@ -1,0 +1,130 @@
+/// Measures bidding accuracy against double-dummy truth: runs self-play
+/// auctions over random deals, solves each deal double dummy, and reports
+/// precision (of games/slams bid, how many make) and recall (of makeable
+/// games/slams, how many were bid) per declaring side.
+///
+///   DDS_LIB=native/libdds.dylib dart run scripts/bidding_accuracy.dart \
+///       [--deals N] [--seed N]
+library;
+
+import 'dart:io';
+
+import 'package:cards_with_cats/bridge/bridge.dart';
+import 'package:cards_with_cats/bridge/dds_ffi.dart';
+import 'package:cards_with_cats/bridge/sayc/selfplay.dart';
+import 'package:cards_with_cats/cards/card.dart';
+
+int gameLevel(Suit? trump) =>
+    trump == null ? 3 : (isMajorSuit(trump) ? 4 : 5);
+
+void main(List<String> args) {
+  int deals = 400;
+  int seed = 1;
+  for (int i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--deals":
+        deals = int.parse(args[++i]);
+      case "--seed":
+        seed = int.parse(args[++i]);
+    }
+  }
+  final dds = DdsBackend.instance;
+  if (dds == null) {
+    print("DDS backend unavailable; set DDS_LIB (cpp/build_libdds.sh)");
+    exit(1);
+  }
+
+  // Confusion counts for games (game-or-higher by a side) and slams.
+  int gamesBid = 0, gamesBidMakeable = 0;
+  int gameChances = 0, gameChancesBid = 0;
+  int slamsBid = 0, slamsBidMakeable = 0;
+  int slamChances = 0, slamChancesBid = 0;
+  int contractsBid = 0, doubledExcluded = 0;
+
+  final strains = [null, ...Suit.values];
+  for (int i = 0; i < deals; i++) {
+    final hands = dealHands(seed, i);
+    final history = runDeal(hands).history;
+
+    // Double-dummy max tricks for each side in each strain (best declarer).
+    int tricksFor(int declarer, Suit? trump) {
+      final ns = dds.solve(hands, trump, (declarer + 1) % 4, const [])!;
+      return declarer % 2 == 0 ? ns : 13 - ns;
+    }
+
+    final maxTricks = List.generate(
+        2,
+        (side) => {
+              for (final s in strains)
+                s: [tricksFor(side, s), tricksFor(side + 2, s)]
+                    .reduce((a, b) => a > b ? a : b)
+            });
+    bool sideHasGame(int side) => strains.any(
+        (s) => maxTricks[side][s]! >= 6 + gameLevel(s));
+    bool sideHasSlam(int side) =>
+        strains.any((s) => maxTricks[side][s]! >= 12);
+
+    int? lastBidIndex;
+    for (int j = history.length - 1; j >= 0; j--) {
+      if (history[j].bidType == BidType.contract) {
+        lastBidIndex = j;
+        break;
+      }
+    }
+    final contract = lastBidIndex == null
+        ? null
+        : history[lastBidIndex].contractBid!;
+    final declSide = lastBidIndex == null ? null : lastBidIndex % 2;
+    final doubled = lastBidIndex != null &&
+        history.sublist(lastBidIndex + 1).any((c) =>
+            c.bidType == BidType.double || c.bidType == BidType.redouble);
+
+    final bidGame = contract != null &&
+        contract.count >= gameLevel(contract.trump);
+    final bidSlam = contract != null && contract.count >= 6;
+
+    // Precision: does the contract actually make double dummy? Doubled
+    // contracts are excluded (they may be sensible sacrifices).
+    if (bidGame && !doubled) {
+      contractsBid++;
+      final makes =
+          maxTricks[declSide!][contract!.trump]! >= 6 + contract.count;
+      gamesBid++;
+      if (makes) gamesBidMakeable++;
+      if (bidSlam) {
+        slamsBid++;
+        if (makes) slamsBidMakeable++;
+      }
+    } else if (bidGame && doubled) {
+      doubledExcluded++;
+    }
+
+    // Recall: for each side with a double-dummy game/slam available, did
+    // that side bid it?
+    for (int side = 0; side < 2; side++) {
+      if (sideHasGame(side)) {
+        gameChances++;
+        if (bidGame && declSide == side) gameChancesBid++;
+      }
+      if (sideHasSlam(side)) {
+        slamChances++;
+        if (bidSlam && declSide == side) slamChancesBid++;
+      }
+    }
+    if ((i + 1) % 100 == 0) stderr.write(".");
+  }
+  stderr.write("\n");
+
+  String pct(int a, int b) =>
+      b == 0 ? "n/a" : "${(100 * a / b).toStringAsFixed(1)}%";
+  print("over $deals deals (double-dummy truth):");
+  print("games+ bid (undoubled): $gamesBid, DD-makeable $gamesBidMakeable "
+      "(precision ${pct(gamesBidMakeable, gamesBid)}); "
+      "$doubledExcluded doubled excluded");
+  print("game chances: $gameChances, bid by that side $gameChancesBid "
+      "(recall ${pct(gameChancesBid, gameChances)})");
+  print("slams bid: $slamsBid, DD-makeable $slamsBidMakeable "
+      "(precision ${pct(slamsBidMakeable, slamsBid)})");
+  print("slam chances: $slamChances, bid by that side $slamChancesBid "
+      "(recall ${pct(slamChancesBid, slamChances)})");
+}

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -915,6 +915,39 @@ void main() {
     });
   });
 
+  group("quantitative notrump raises", () {
+    test("after Stayman finds no fit", () {
+      final h = ["1NT", "pass", "2C", "pass", "2D", "pass"];
+      expect(openingBid("765", "AJT5", "AQJ", "AQ8", history: h), "6NT"); // 18
+      expect(openingBid("Q65", "AJT5", "AQJ", "Q84", history: h), "4NT"); // 16
+      expect(openingBid("Q65", "AJT5", "AJ2", "Q84", history: h), "3NT"); // 14
+    });
+
+    test("after a transfer with slam values", () {
+      expect(
+          openingBid("QJ75", "KQJ72", "Q", "AK5",
+              history: ["1NT", "pass", "2D", "pass", "2H", "pass"]),
+          "6NT"); // 18 with 5 hearts
+    });
+
+    test("opener accepts the invite with a maximum", () {
+      final h = ["1NT", "pass", "2C", "pass", "2D", "pass", "4NT", "pass"];
+      expect(openingBid("AQ32", "KQ2", "A32", "Q32", history: h), "6NT"); // 17
+      expect(openingBid("A432", "KQ2", "A32", "Q32", history: h), "Pass"); // 15
+      expect(
+          openingBid("AJ3", "KQ3", "AQ32", "KQ2",
+              history: ["2NT", "pass", "3C", "pass", "3D", "pass", "4NT", "pass"]),
+          "6NT"); // 21
+    });
+
+    test("over a 2NT opening", () {
+      expect(
+          openingBid("KQ875", "A", "Q73", "KJ92",
+              history: ["2NT", "pass", "3H", "pass", "3S", "pass"]),
+          "6NT"); // 15 opposite 20-21
+    });
+  });
+
   group("slam conventions", () {
     test("Jacoby sequences launch Blackwood", () {
       expect(

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1067,6 +1067,27 @@ void main() {
   });
 
   group("responses over interference", () {
+    test("responder doesn't sell out with an opener opposite", () {
+      final h = ["1D", "pass", "1H", "1S", "pass", "pass"];
+      // 13 points, no fit, no stopper: action double (and four of their
+      // suit makes penalties attractive).
+      expect(openingBid("8762", "K632", "AQ", "A86", history: h), "Double");
+      // 13+ with a stopper: game in notrump.
+      expect(openingBid("KJ62", "K632", "AQ", "986", history: h), "3NT");
+      // 11-12 with a stopper: natural notrump.
+      expect(openingBid("KJ62", "KQ32", "Q2", "986", history: h), "1NT");
+      // A weak hand still passes.
+      expect(openingBid("8762", "K632", "Q2", "986", history: h), "Pass");
+    });
+
+    test("opener advances the action double", () {
+      final h = ["1D", "pass", "1H", "1S", "pass", "pass", "X", "pass"];
+      // Trump length: convert to penalties.
+      expect(openingBid("A54", "Q8", "KJ752", "KQ4", history: h), "Pass");
+      // Singleton in their suit: pull to the cheapest fit.
+      expect(openingBid("4", "Q87", "KJ7652", "KQ4", history: h), "2H");
+    });
+
     test("opener's notrump answer to the double is level-aware", () {
       final h = ["1S", "3D", "X", "pass"];
       // 12-14 balanced can't offer 3NT over the jump overcall: rebid the

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1067,6 +1067,22 @@ void main() {
   });
 
   group("responses over interference", () {
+    test("opener's notrump answer to the double is level-aware", () {
+      final h = ["1S", "3D", "X", "pass"];
+      // 12-14 balanced can't offer 3NT over the jump overcall: rebid the
+      // suit and let responder pass with the 8-card fit.
+      expect(openingBid("AQJ42", "73", "K54", "Q86", history: h), "3S");
+      // 15+ with a stopper commits to game.
+      expect(openingBid("AQJ42", "73", "AK4", "K86", history: h), "3NT");
+      // Responder's 3-card support passes the spade rebid.
+      expect(
+          openingBid("876", "AK962", "Q82", "T5",
+              history: ["1S", "3D", "X", "pass", "3S", "pass"]),
+          "Pass");
+      // With four hearts, opener answers the double in the 9-card fit.
+      expect(openingBid("AQJ42", "K873", "5", "Q86", history: h), "3H");
+    });
+
     test("competitive raise with four trumps over a jump overcall", () {
       // 10 points with a guaranteed nine-card fit: raise, don't double.
       expect(openingBid("8765", "AK962", "Q8", "T5", history: ["1S", "3D"]),

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1067,6 +1067,20 @@ void main() {
   });
 
   group("responses over interference", () {
+    test("competitive raise with four trumps over a jump overcall", () {
+      // 10 points with a guaranteed nine-card fit: raise, don't double.
+      expect(openingBid("8765", "AK962", "Q8", "T5", history: ["1S", "3D"]),
+          "3S");
+      // With only three trumps the negative double still shows hearts.
+      expect(openingBid("876", "AK962", "Q82", "T5", history: ["1S", "3D"]),
+          "Double");
+      // Limit-raise strength still shows 11-12.
+      final limit = selectSaycBid(hand("8765", "AKJ62", "Q8", "T5"),
+          ["1S", "3D"].map(BidAction.fromString).toList());
+      expect(limit.action.toString(), "3S");
+      expect(limit.meaning.totalPoints, const Range(low: 11, high: 12));
+    });
+
     test("negative doubles", () {
       final result = selectSaycBid(hand("432", "KQ32", "Q32", "J32"),
           ["1D", "1S"].map(BidAction.fromString).toList());


### PR DESCRIPTION
- "Action" double with no clear bid rather than allowing opponents to play a cheap contract
- Quantitative 4NT raises to invite NT slam
- `bidding_accuracy` script to measure how often double-dummy-makeable games and slams are bid