### PR TITLE
Improve layout and card display

### DIFF
--- a/assets/doc/about.md
+++ b/assets/doc/about.md
@@ -108,7 +108,11 @@ only when they make their exact bid.
 Bridge is a game played by two teams of partners. Your partner is at the top of the screen and the
 opponents are on the sides. A round begins with an "auction", where players bid to set the trump
 suit (or to have no trump suit, "NT") and to say how many tricks they will win with that
-trump. See [here](https://www.acbl.org/learn/) for more detailed rules.
+trump. During play, the partner of the player who first bid the trump suit is the "declarer" and
+their partner is the "dummy". The dummy's cards are turned face up for all players to see, and the
+declarer chooses the cards to play.
+
+See [here](https://www.acbl.org/learn/) for more detailed rules.
 
 ### Bidding
 The bidding system that the AI players use is mostly [Standard American Yellow Card](https://www.bridgebum.com/sayc.php) (SAYC),
@@ -117,7 +121,7 @@ including:
 - Negative doubles
 - Weak opening two-bids, strong 2♣
 - Weak jump overcalls
-- 1NT opening with 15-17 points, Stayman and Jacoby transfers
+- 1NT opening with 15-17 points, Stayman, and Jacoby transfers
 - Blackwood and Gerber
 
 You can see the meaning of a bid that a player (including yourself) has made by tapping it in the
@@ -125,7 +129,7 @@ bid table. If you make a bid that's not interpreted how you expected, you can us
 button to rewind the auction to your most recent action.
 
 The AI players do not currently use any conventions for playing cards (e.g. playing high then low to
-indicate an even number of cards).
+indicate an even number of cards in the suit).
 
 ### Scoring
 Matches are scored as "duplicate teams". Each hand you play is also played separately by AI. The
@@ -136,8 +140,16 @@ For example, suppose you bid and make a contract of 2♠, while in the duplicate
 your position also bids 2♠ but fails to make it by one trick. Your score is +110, and your AI
 counterpart's score is -50. The difference is 160 points in your favor, which translates to +4 IMPs.
 
+After each round ends, you can review the bidding and play for both your hand and the duplicate
+hand. The "double dummy" result for your hand is also shown; this is what the result would be if all
+players played perfectly and with full knowledge of where all the cards are.
+
 The length of a match is set in the preferences and can be 1, 4, or 8 hands. The winner of the match
 is determined by the IMPs accumulated over all hands.
+
+### Preferences
+In the Preferences screen, you can set the length of a match and control whether the dummy is always
+at the top of the screen (your position will be rotated as needed).
 
 ## License
 

--- a/lib/bridge/bridge.dart
+++ b/lib/bridge/bridge.dart
@@ -558,6 +558,7 @@ class BridgeRound extends BaseTrickRound {
 
   BridgePlayer currentPlayer() => players[currentPlayerIndex()];
 
+  @override
   List<PlayingCard> legalPlaysForCurrentPlayer() {
     return legalPlays(currentPlayer().hand, currentTrick);
   }

--- a/lib/bridge_ui.dart
+++ b/lib/bridge_ui.dart
@@ -1001,7 +1001,10 @@ class _BidHistoryTableState extends State<BidHistoryTable> {
             });
           },
           child: Container(
-            color: isExplainingBid ? Colors.white : Colors.transparent,
+            decoration: BoxDecoration(
+                borderRadius: const BorderRadius.all(Radius.circular(12)),
+                color: isExplainingBid ? Colors.white : Colors.transparent,
+            ),
             child: Padding(padding: const EdgeInsets.symmetric(horizontal: 8), child: Text(
               bidHistory[bidIndex].action.symbolString(),
               textAlign: TextAlign.center))),
@@ -1015,9 +1018,12 @@ class _BidHistoryTableState extends State<BidHistoryTable> {
       }
       final bidsUpToSelection = bidHistory.sublist(0, bidIndex).map((b) => b.action).toList();
       final meaning = describeSaycCall(bidsUpToSelection, bidHistory[bidIndex].action);
-      return Padding(padding: EdgeInsets.only(bottom: 5), child: Container(
+      return Padding(padding: const EdgeInsets.only(bottom: 5), child: Container(
         width: 200,
-        color: Colors.white70,
+        decoration: const BoxDecoration(
+          borderRadius: const BorderRadius.all(Radius.circular(8)),
+          color: Colors.white70,
+        ),
         child: paddingAll(4, Text(
           meaning != null ? meaning.description : "No specific meaning",
           style: const TextStyle(fontSize: 10),

--- a/lib/bridge_ui.dart
+++ b/lib/bridge_ui.dart
@@ -122,28 +122,6 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
   BridgeRound get round => match.currentRound;
   BridgeRound get duplicateRound => match.duplicateRound;
 
-  // During play, hands/tricks/avatars can be rotated so the dummy is drawn at
-  // the top of the display. Returns the offset to add to a player index to get
-  // its display position; 0 if rotation is disabled or not applicable.
-  int _displayRotation() {
-    if (!widget.rotateDummyToTop) {
-      return 0;
-    }
-    // Normal orientation while bidding and when showing all hands after the
-    // round ends. Keep any rotation until the final trick is done animating.
-    if (animationMode == AnimationMode.none && (round.status != BridgeRoundStatus.playing || round.isOver())) {
-      return 0;
-    }
-    final contract = round.contract;
-    if (contract == null) {
-      return 0;
-    }
-    return (2 - contract.dummy) % 4;
-  }
-
-  int _displayIndexForPlayer(int playerIndex) =>
-      (playerIndex + _displayRotation()) % 4;
-
   @override
   void initState() {
     super.initState();
@@ -166,6 +144,28 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
     super.deactivate();
     matchUpdateSubscription.cancel();
   }
+
+  // During play, hands/tricks/avatars can be rotated so the dummy is drawn at
+  // the top of the display. Returns the offset to add to a player index to get
+  // its display position; 0 if rotation is disabled or not applicable.
+  int _displayRotation() {
+    if (!widget.rotateDummyToTop) {
+      return 0;
+    }
+    // Normal orientation while bidding and when showing all hands after the
+    // round ends. Keep any rotation until the final trick is done animating.
+    if (animationMode == AnimationMode.none && (round.status != BridgeRoundStatus.playing || round.isOver())) {
+      return 0;
+    }
+    final contract = round.contract;
+    if (contract == null) {
+      return 0;
+    }
+    return (2 - contract.dummy) % 4;
+  }
+
+  int _displayIndexForPlayer(int playerIndex) =>
+      (playerIndex + _displayRotation()) % 4;
 
   void _updateMatch(BridgeMatch newMatch) {
     setState(() {
@@ -248,6 +248,16 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
     return (round.status == BridgeRoundStatus.bidding &&
         aiMode == AiMode.humanPlayer0 &&
         round.currentBidder() == 0);
+  }
+
+  bool _isWaitingForHumanPlay() {
+    if (round.status != .playing || round.isOver()) {
+      return false;
+    }
+    int pi = round.currentPlayerIndex();
+    return pi == 0
+        || (pi == 2 && round.contract!.declarer == 0)
+        || (pi == 2 && round.contract!.declarer == 2);
   }
 
   bool hasHumanPlayer() {
@@ -782,6 +792,12 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
                 (t.leader + rotation) % 4, t.cards, (t.winner + rotation) % 4))
           ];
 
+    bool maybeTransparent = _isWaitingForHumanPlay()
+        && displayCurrentTrick.cards.isNotEmpty
+        && displayCurrentTrick.cards.length < 4;
+
+    // TODO: main menu icon button locatioin doesn't always update
+
     return TrickCards(
       layout: layout,
       currentTrick: displayCurrentTrick,
@@ -793,6 +809,7 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
       suitOrder: _suitDisplayOrder(),
       onTrickCardAnimationFinished: _trickCardAnimationFinished,
       onTrickToWinnerAnimationFinished: _trickToWinnerAnimationFinished,
+      transparentIfOverPlayerCards: maybeTransparent,
     );
   }
 
@@ -827,17 +844,16 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
     return showScoreOverlay && !widget.dialogVisible && _isPlayInProgress();
   }
 
-  Widget _scoreOverlayButton() {
-    return Opacity(opacity: 0.6, child: Padding(
-      padding: const EdgeInsets.fromLTRB(10, 80, 10, 10),
-      child: FloatingActionButton(
-        onPressed: () {
-          setState(() {
-            showScoreOverlay = !showScoreOverlay;
-          });
-        },
-        child: Icon(showScoreOverlay ? Icons.search_off : Icons.search),
-      ),
+  Widget _scoreOverlayButton(Layout layout) {
+    return Opacity(opacity: 0.8, child: scoreToggleIconButton(
+      layout: layout,
+      onPressed: () {
+        setState(() {
+          showScoreOverlay = !showScoreOverlay;
+        });
+      },
+      showingScore: showScoreOverlay,
+      location: .bottomRight,
     ));
   }
 
@@ -941,7 +957,7 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
           ),
         PlayerMoods(layout: layout, moods: playerMoods, durationMillis: 5000),
         if (_shouldShowScoreOverlay()) _scoreOverlay(),
-        if (_shouldShowScoreOverlayToggle()) _scoreOverlayButton(),
+        if (_shouldShowScoreOverlayToggle()) _scoreOverlayButton(layout),
       ],
     );
   }

--- a/lib/common_ui.dart
+++ b/lib/common_ui.dart
@@ -52,7 +52,8 @@ class Layout {
             : 0.5;
     final centerX = ca.left + ca.width * centerXFrac;
     final centerY = ca.top + ca.height * centerYFrac;
-    return Rect.fromLTWH(centerX - cs.width / 2, centerY - cs.height / 2, cs.width, cs.height);
+    final fullRect = Rect.fromLTWH(centerX - cs.width / 2, centerY - cs.height / 2, cs.width, cs.height);
+    return centeredSubrectWithAspectRatio(fullRect, cardAspectRatio);
   }
 
   Rect cardOriginAreaForPlayer(int playerIndex) {
@@ -106,7 +107,9 @@ class PositionedCard extends StatelessWidget {
   final double cardAspectRatio;
   final double dimming;
   final double rotation;
+  final double opacity;
   final bool isTrump;
+  final bool ignorePointer;
   final void Function(PlayingCard)? onCardClicked;
   final Color? backgroundColor;
 
@@ -118,6 +121,8 @@ class PositionedCard extends StatelessWidget {
     this.onCardClicked,
     this.dimming = 0.0,
     this.rotation = 0.0,
+    this.opacity = 1.0,
+    this.ignorePointer = false,
     this.isTrump = false,
     this.backgroundColor,
   });
@@ -167,16 +172,27 @@ class PositionedCard extends StatelessWidget {
     // ClipRRect clips the background color and dimming rectangle
     // to the card's rounded rect.
     return Positioned.fromRect(
-        rect: cardRect,
-        child: Transform.rotate(angle: rotation, child: GestureDetector(
-            onTapDown: onCardClicked != null ? ((tap) => onCardClicked!(card)) : null,
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(cornerRadius),
-              child: Container(
-                color: bgColor,
-                child: Stack(children: cardStack)
-              )
-            ) )));
+      rect: cardRect,
+      child: Transform.rotate(
+        angle: rotation,
+        child: GestureDetector(
+          onTapDown: onCardClicked != null ? ((tap) => onCardClicked!(card)) : null,
+          child: Opacity(
+            opacity: opacity,
+            child: IgnorePointer(
+              ignoring: ignorePointer,
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(cornerRadius),
+                child: Container(
+                  color: bgColor,
+                  child: Stack(children: cardStack)
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }
 
@@ -572,10 +588,12 @@ class TrickCards extends StatelessWidget {
   final int numPlayers;
   final void Function() onTrickCardAnimationFinished;
   final void Function() onTrickToWinnerAnimationFinished;
-  final List<DisplayedHand>? displayedHands;
-  final List<Suit>? suitOrder;
+  final List<DisplayedHand> displayedHands;
+  final List<Suit> suitOrder;
   final Suit? trumpSuit;
   final Map<PlayingCard, Color>? cardBackgroundColors;
+  final bool transparentIfOverPlayerCards;
+  final Function(PlayingCard)? onCardClicked;
 
   const TrickCards({
     super.key,
@@ -586,10 +604,12 @@ class TrickCards extends StatelessWidget {
     required this.numPlayers,
     required this.onTrickCardAnimationFinished,
     required this.onTrickToWinnerAnimationFinished,
-    this.displayedHands,
-    this.suitOrder,
+    required this.displayedHands,
+    required this.suitOrder,
     this.trumpSuit,
     this.cardBackgroundColors,
+    this.transparentIfOverPlayerCards = false,
+    this.onCardClicked,
   });
 
   @override
@@ -618,22 +638,54 @@ class TrickCards extends StatelessWidget {
     return Stack(children: cardWidgets);
   }
 
-  Widget _trickCardForPlayer(final Layout layout, final PlayingCard card, int playerIndex) {
+  Widget _trickCardForPlayer(
+      final Layout layout, final PlayingCard card, int playerIndex,
+      {double opacity = 1, bool ignorePointer = false}) {
     final cardRect = layout.trickCardAreaForPlayer(playerIndex);
     return PositionedCard(
         rect: cardRect,
         card: card,
         isTrump: card.suit == trumpSuit,
         backgroundColor: cardBackgroundColors?[card],
+        onCardClicked: onCardClicked,
+        opacity: opacity,
+        ignorePointer: ignorePointer,
     );
   }
 
+  // In the static case, use transparency if a trick card would intersect any
+  // of the displayed player cards and if `transparentIfOverPlayerCards` is set,
+  // which it is when the human is deciding which card to play.
   List<Widget> _staticTrickCards(
       final Layout layout, int leader, int numPlayers, List<PlayingCard> cards) {
+
+    double scale = 1.0;
+    final List<Rect> handRects = [];
+
+    if (transparentIfOverPlayerCards) {
+      scale = computeScaleForNonintersectingPlayerHands(
+          layout: layout, playerHands: displayedHands, suitOrder: suitOrder);
+      for (final h in displayedHands) {
+        var rects = playerHandCardRects(
+            layout, h.cards, suitOrder,
+            playerIndex: h.playerIndex,
+            displayStyle: h.displayStyle,
+            scaleMultiplier: scale,
+            leaveAvatarSpace: h.leaveAvatarSpace).values.toList();
+        if (h.playerIndex == 1 || h.playerIndex == 3) {
+          rects = rects.map((r) => Rect.fromCenter(center: r.center, width: r.height, height: r.width)).toList();
+        }
+        handRects.addAll(rects);
+      }
+    }
+
     List<Widget> cardWidgets = [];
     for (int i = 0; i < cards.length; i++) {
       int p = (leader + i) % numPlayers;
-      cardWidgets.add(_trickCardForPlayer(layout, cards[i], p));
+      final trickCardRect = layout.trickCardAreaForPlayer(p);
+      bool intersects = transparentIfOverPlayerCards && anyRectsIntersect([trickCardRect], handRects);
+      double opacity = intersects ? 0.7 : 1.0;
+      cardWidgets.add(_trickCardForPlayer(layout, cards[i], p, opacity: opacity, ignorePointer: intersects));
     }
     return cardWidgets;
   }
@@ -648,13 +700,15 @@ class TrickCards extends StatelessWidget {
     final animPlayer = (leader + cards.length - 1) % numPlayers;
     final endRect = layout.trickCardAreaForPlayer(animPlayer);
     var startRect = layout.cardOriginAreaForPlayer(animPlayer);
-    List<DisplayedHand> matchingDisplayedHands = displayedHands != null ? displayedHands!.where((d) => d.playerIndex == animPlayer).toList() : [];
+    List<DisplayedHand> matchingDisplayedHands = displayedHands.where((d) => d.playerIndex == animPlayer).toList();
     bool startsFromVisibleHand = false;
     int? playerDisplayIndex;
     if (matchingDisplayedHands.isNotEmpty) {
       final dh = matchingDisplayedHands[0];
       // We want to know where the card was drawn in the player's hand. It's not
       // there now, so we have to compute the card rects as if it were.
+      // FIXME: This should take into account all displayed hands because they
+      // might need to be scaled down to avoid intersections.
       final previousHandCards = [...dh.cards, cards.last];
       startRect =
           playerHandCardRects(layout, previousHandCards, suitOrder!, playerIndex: animPlayer, displayStyle: dh.displayStyle, leaveAvatarSpace: dh.leaveAvatarSpace)[cards.last]!;
@@ -684,6 +738,7 @@ class TrickCards extends StatelessWidget {
               isTrump: cards.last.suit == trumpSuit,
               backgroundColor: cardBackgroundColors?[cards.last],
               rotation: rotation,
+              onCardClicked: onCardClicked,
           );
         }));
 
@@ -908,6 +963,15 @@ class PlayerHandParams {
     this.displayStyle = HandDisplayStyle.normal,
     this.leaveAvatarSpace = true,
   });
+
+  DisplayedHand toDisplayedHand() {
+    return DisplayedHand(
+      cards: cards,
+      playerIndex: playerIndex,
+      displayStyle: displayStyle,
+      leaveAvatarSpace: leaveAvatarSpace,
+    );
+  }
 }
 
 class MultiplePlayerHandCards extends StatelessWidget {
@@ -926,16 +990,53 @@ class MultiplePlayerHandCards extends StatelessWidget {
     this.cardBackgroundColors,
   });
 
-  static bool anyRectsIntersect(List<Rect> rects1, List<Rect> rects2) {
-    for (final r1 in rects1) {
-      for (final r2 in rects2) {
-        if (!r1.intersect(r2).isEmpty) {
-          return true;
-        }
+  @override
+  Widget build(BuildContext context) {
+    final scaleMultiplier = computeScaleForNonintersectingPlayerHands(
+      layout: layout,
+      playerHands: playerHands.map((h) => h.toDisplayedHand()).toList(),
+      suitOrder: suitOrder,
+    );
+
+    return Stack(children: [
+      ...playerHands.map((ph) => PlayerHandCards(
+        key: ph.key,
+        layout: layout,
+        playerIndex: ph.playerIndex,
+        cards: ph.cards,
+        highlightedCards: ph.highlightedCards,
+        suitDisplayOrder: suitOrder,
+        animateFromCards: ph.animateFromCards,
+        trumpSuit: trumpSuit,
+        cardBackgroundColors: cardBackgroundColors,
+        onCardClicked: ph.onCardClicked,
+        displayStyle: ph.displayStyle,
+        scaleMultiplier: scaleMultiplier,
+        leaveAvatarSpace: ph.leaveAvatarSpace,
+      ))
+    ]);
+  }
+}
+
+bool anyRectsIntersect(List<Rect> rects1, List<Rect> rects2) {
+  for (final r1 in rects1) {
+    for (final r2 in rects2) {
+      if (!r1.intersect(r2).isEmpty) {
+        return true;
       }
     }
-    return false;
   }
+  return false;
+}
+
+// Returns the factor by which all cards in `playerHands` should be scaled so
+// that no two cards from different players will intersect. The return value
+// will be 1 if no scaling is needed; otherwise it will be between 0 and 1.
+double computeScaleForNonintersectingPlayerHands({
+  required Layout layout,
+  required List<DisplayedHand> playerHands,
+  required List<Suit> suitOrder,
+}) {
 
   bool hasCardIntersectionAtScaleMultiplier(double scaleMultiplier) {
     if (playerHands.length <= 1) {
@@ -978,54 +1079,29 @@ class MultiplePlayerHandCards extends StatelessWidget {
     return false;
   }
 
-  double computeBestScaleMultiplier() {
-    // Get all the card rects and see if any rect for player A intersects
-    // a rect for player B. If so, adjust scaleMultiplier until there are
-    // no more intersections.
-    if (!hasCardIntersectionAtScaleMultiplier(1)) {
-      return 1;
-    }
-    double min = 0;
-    double max = 1;
-    double current = 0.5;
-    double best = 0;
-    const nIters = 8;
-    for (int i = 0; i < nIters; i++) {
-      current = (min + max) / 2.0;
-      if (hasCardIntersectionAtScaleMultiplier(current)) {
-        // Too big, need to reduce scale.
-        max = current;
-      }
-      else {
-        best = current;
-        min = current;
-      }
-    }
-    return best;
+  // Get all the card rects and see if any rect for player A intersects
+  // a rect for player B. If so, adjust scaleMultiplier until there are
+  // no more intersections.
+  if (!hasCardIntersectionAtScaleMultiplier(1)) {
+    return 1;
   }
-
-  @override
-  Widget build(BuildContext context) {
-    final scaleMultiplier = computeBestScaleMultiplier();
-
-    return Stack(children: [
-      ...playerHands.map((ph) => PlayerHandCards(
-        key: ph.key,
-        layout: layout,
-        playerIndex: ph.playerIndex,
-        cards: ph.cards,
-        highlightedCards: ph.highlightedCards,
-        suitDisplayOrder: suitOrder,
-        animateFromCards: ph.animateFromCards,
-        trumpSuit: trumpSuit,
-        cardBackgroundColors: cardBackgroundColors,
-        onCardClicked: ph.onCardClicked,
-        displayStyle: ph.displayStyle,
-        scaleMultiplier: scaleMultiplier,
-        leaveAvatarSpace: ph.leaveAvatarSpace,
-      ))
-    ]);
+  double min = 0;
+  double max = 1;
+  double current = 0.5;
+  double best = 0;
+  const nIters = 8;
+  for (int i = 0; i < nIters; i++) {
+    current = (min + max) / 2.0;
+    if (hasCardIntersectionAtScaleMultiplier(current)) {
+      // Too big, need to reduce scale.
+      max = current;
+    }
+    else {
+      best = current;
+      min = current;
+    }
   }
+  return best;
 }
 
 LinkedHashMap<PlayingCard, Rect> _playerHandCardRectsForTopOrBottom(
@@ -1296,7 +1372,6 @@ LinkedHashMap<PlayingCard, Rect> _normalCardRects(
   else {
     return _playerHandCardRectsForLeftOrRight(layout, cards, suitOrder, playerIndex: playerIndex, scaleMultiplier: scaleMultiplier, leaveAvatarSpace: leaveAvatarSpace);
   }
-  throw Exception();
 }
 
 LinkedHashMap<PlayingCard, Rect> playerHandCardRects(
@@ -1308,6 +1383,51 @@ LinkedHashMap<PlayingCard, Rect> playerHandCardRects(
     HandDisplayStyle.dummy => _dummyCardRects(layout: layout, cards: cards, suitOrder: suitOrder, playerIndex: playerIndex, scaleMultiplier: scaleMultiplier),
     HandDisplayStyle.normal => _normalCardRects(layout, cards, suitOrder, playerIndex: playerIndex, scaleMultiplier: scaleMultiplier, leaveAvatarSpace: leaveAvatarSpace),
   };
+}
+
+enum IconButtonLocation {topLeft, bottomRight}
+
+Widget menuIconButton({
+  void Function()? onPressed,
+  required Layout layout,
+  IconButtonLocation location = .topLeft,
+}) {
+  final padding = switch (location) {
+    .topLeft => const EdgeInsets.only(top: 10, left: 10),
+    .bottomRight => EdgeInsets.only(
+      top: layout.displaySize.height - 80,
+      left: layout.displaySize.width - 80,
+    )
+  };
+  return Padding(
+    padding: padding,
+    child: FloatingActionButton(
+      onPressed: onPressed,
+      child: const Icon(Icons.menu),
+    )
+  );
+}
+
+Widget scoreToggleIconButton({
+  void Function()? onPressed,
+  required Layout layout,
+  required bool showingScore,
+  IconButtonLocation location = .topLeft,
+}) {
+  final padding = switch (location) {
+      .topLeft => const EdgeInsets.only(top: 80, left: 10),
+      .bottomRight => EdgeInsets.only(
+        top: layout.displaySize.height - 150,
+        left: layout.displaySize.width - 80,
+      ),
+  };
+  return Padding(
+    padding: padding,
+    child: FloatingActionButton(
+      onPressed: onPressed,
+      child: Icon(showingScore ? Icons.search_off : Icons.search),
+    ),
+  );
 }
 
 Layout computeLayout(BuildContext context) {

--- a/lib/hearts_ui.dart
+++ b/lib/hearts_ui.dart
@@ -488,20 +488,6 @@ class _HeartsMatchState extends State<HeartsMatchDisplay> {
     widget.mainMenuFn();
   }
 
-  Widget scoreOverlayButton() {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(10, 80, 10, 10),
-      child: FloatingActionButton(
-        onPressed: () {
-          setState(() {
-            showScoreOverlay = !showScoreOverlay;
-          });
-        },
-        child: Icon(showScoreOverlay ? Icons.search_off : Icons.search),
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final layout = computeLayout(context);
@@ -531,7 +517,15 @@ class _HeartsMatchState extends State<HeartsMatchDisplay> {
         PlayerMoods(layout: layout, moods: playerMoods),
         if (shouldShowScoreOverlay())
           PlayerMessagesOverlay(layout: layout, messages: _currentRoundScoreMessages()),
-        if (shouldShowScoreOverlayToggle()) scoreOverlayButton(),
+        if (shouldShowScoreOverlayToggle()) scoreToggleIconButton(
+          layout: layout,
+          onPressed: () {
+            setState(() {
+              showScoreOverlay = !showScoreOverlay;
+            });
+          },
+          showingScore: showScoreOverlay,
+        ),
         // Text("${match.scores} ${round.status} ${_shouldShowPassDialog()}"),
       ],
     );

--- a/lib/hearts_ui.dart
+++ b/lib/hearts_ui.dart
@@ -316,9 +316,9 @@ class _HeartsMatchState extends State<HeartsMatchDisplay> {
     Map<PlayingCard, Color> backgrounds = {};
     if (widget.tintPointCards) {
       for (final r in Rank.values) {
-        backgrounds[PlayingCard(r, Suit.hearts)] = Colors.redAccent.shade100;
+        backgrounds[PlayingCard(r, Suit.hearts)] = Colors.red.shade200;
       }
-      backgrounds[queenOfSpades] = Colors.red;
+      backgrounds[queenOfSpades] = Colors.redAccent.shade200;
       if (round.rules.jdMinus10) {
         backgrounds[jackOfDiamonds] = Colors.amber;
       }
@@ -327,7 +327,7 @@ class _HeartsMatchState extends State<HeartsMatchDisplay> {
       if (round.players[0].hand.length == 13) {
         final receivedCards = round.players[0].receivedCards;
         for (final c in receivedCards) {
-          backgrounds[c] = Colors.lightBlue;
+          backgrounds[c] = Colors.lightBlue.shade200;
         }
       }
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,7 +45,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      // debugShowCheckedModeBanner: false,
+      debugShowCheckedModeBanner: false,
       title: appTitle,
       theme: ThemeData(
         primarySwatch: Colors.blue,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,7 +45,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      debugShowCheckedModeBanner: false,
+      // debugShowCheckedModeBanner: false,
       title: appTitle,
       theme: ThemeData(
         primarySwatch: Colors.blue,
@@ -806,14 +806,17 @@ class _MyHomePageState extends State<MyHomePage> {
         ))));
   }
 
-  Widget _menuIcon() {
-    return Padding(
-      padding: const EdgeInsets.all(10),
-      child: Opacity(opacity: 0.6, child: FloatingActionButton(
-        onPressed: _showMainMenu,
-        child: const Icon(Icons.menu),
-      )),
-    );
+  Widget _menuIcon(Layout layout) {
+    // Minor hack: for bridge rounds, move the menu icon to the bottom where
+    // it's less likely to interfere with the dummy.
+    final location = matchType == GameType.bridge
+        ? IconButtonLocation.bottomRight : IconButtonLocation.topLeft;
+    final opacity = matchType == GameType.bridge ? 0.8 : 1.0;
+    return Opacity(opacity: opacity, child: menuIconButton(
+      layout: layout,
+      onPressed: _showMainMenu,
+      location: location,
+    ));
   }
 
   // A Fluttter bug causes most animations to take nearly zero time if the
@@ -974,7 +977,7 @@ class _MyHomePageState extends State<MyHomePage> {
               onClose: _showMainMenu,
               initialGameType: matchType,
           ),
-          if (dialogMode == DialogMode.none) _menuIcon(),
+          if (dialogMode == DialogMode.none) _menuIcon(layout),
 
           if (runningTimingTestAnimation) timingTestAnimation(),
           if (showingAnimationSpeedWarningDialog) animationSpeedWarningDialog(layout.displaySize),


### PR DESCRIPTION
- Make the current trick cards partially transparent if they cover other visible cards, so that the human player can see behind them when deciding which card to play
- For bridge, move the menu and info buttons to the bottom right so they're less likely to obscure the dummy's cards
- Adjust tinted backgrounds for point cards in Hearts
- Documentation updates