### PR TITLE
Fix bug that could cause illegal bids, add fuzz test

### DIFF
--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -6180,28 +6180,15 @@ class SaycBid {
 /// outrank the last one, a double needs an undoubled opposing contract, and
 /// a redouble needs our own doubled contract.
 bool isLegalCall(BidAction call, List<BidAction> history) {
-  int? lastBidIndex;
-  for (int i = history.length - 1; i >= 0; i--) {
-    if (history[i].bidType == BidType.contract) {
-      lastBidIndex = i;
-      break;
-    }
-  }
-  if (call.bidType == BidType.pass) return true;
-  final n = history.length;
-  if (call.bidType == BidType.contract) {
-    if (lastBidIndex == null) return true;
-    return call.contractBid!.isHigherThan(history[lastBidIndex].contractBid!);
-  }
-  if (lastBidIndex == null) return false;
-  final since = history.sublist(lastBidIndex + 1);
-  final doubled = since.any((c) => c.bidType == BidType.double);
-  final redoubled = since.any((c) => c.bidType == BidType.redouble);
-  final bidByOpponents = (n - lastBidIndex) % 2 == 1;
-  if (call.bidType == BidType.double) {
-    return bidByOpponents && !doubled && !redoubled;
-  }
-  return !bidByOpponents && doubled && !redoubled; // redouble
+  final bids = [
+    for (int i = 0; i < history.length; i++) PlayerBid(i % 4, history[i])
+  ];
+  return switch (call.bidType) {
+    BidType.pass => true,
+    BidType.contract => canCurrentBidderMakeContractBid(bids, call.contractBid!),
+    BidType.double => canCurrentBidderDouble(bids),
+    BidType.redouble => canCurrentBidderRedouble(bids),
+  };
 }
 
 SaycBid _legalized(SaycBid bid, List<BidAction> history) =>

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -2531,6 +2531,10 @@ List<SaycRule> _responderRebidAfterSuitRules(
   // Our response was 2NT: Jacoby over a major, natural over a minor.
   if (response == BidAction.noTrump(2)) {
     if (oMajor) {
+      if (rebid == ContractBid.noTrump(4)) {
+        // Opener went straight to Blackwood over the Jacoby raise.
+        return blackwoodAnswerRules();
+      }
       if (rebid == ContractBid(4, oSuit)) {
         return [
           SaycRule(
@@ -6172,20 +6176,60 @@ class SaycBid {
 /// Choose a call for `hand` given the auction so far (dealer's call first).
 /// Positions outside the rule tables are handled by the constraint-based
 /// fallback bidder (descriptions prefixed with "Fallback:").
+/// Whether `call` is legal given the auction so far: a contract bid must
+/// outrank the last one, a double needs an undoubled opposing contract, and
+/// a redouble needs our own doubled contract.
+bool isLegalCall(BidAction call, List<BidAction> history) {
+  int? lastBidIndex;
+  for (int i = history.length - 1; i >= 0; i--) {
+    if (history[i].bidType == BidType.contract) {
+      lastBidIndex = i;
+      break;
+    }
+  }
+  if (call.bidType == BidType.pass) return true;
+  final n = history.length;
+  if (call.bidType == BidType.contract) {
+    if (lastBidIndex == null) return true;
+    return call.contractBid!.isHigherThan(history[lastBidIndex].contractBid!);
+  }
+  if (lastBidIndex == null) return false;
+  final since = history.sublist(lastBidIndex + 1);
+  final doubled = since.any((c) => c.bidType == BidType.double);
+  final redoubled = since.any((c) => c.bidType == BidType.redouble);
+  final bidByOpponents = (n - lastBidIndex) % 2 == 1;
+  if (call.bidType == BidType.double) {
+    return bidByOpponents && !doubled && !redoubled;
+  }
+  return !bidByOpponents && doubled && !redoubled; // redouble
+}
+
+SaycBid _legalized(SaycBid bid, List<BidAction> history) =>
+    isLegalCall(bid.action, history)
+        ? bid
+        : SaycBid(BidAction.pass(), BidMeaning(description: "Nothing legal to bid"));
+
 SaycBid selectSaycBid(List<PlayingCard> hand, List<BidAction> history,
     {Vulnerability vulnerability = Vulnerability.neither}) {
   final rules = saycRulesForAuction(history);
-  if (rules == null) return fallbackBid(hand, history);
+  if (rules == null) return _legalized(fallbackBid(hand, history), history);
   final analysis = HandAnalysis(hand);
   for (final rule in rules) {
+    // Rules are written for the auctions the engine expects; a human partner
+    // or opponent can create positions where a rule's action is no longer
+    // legal (e.g. a "return to game" bid below the current contract). Skip
+    // such rules so a later one (usually pass) can apply.
+    if (!isLegalCall(rule.action, history)) continue;
     if (rule.matches(analysis)) return SaycBid(rule.action, rule.meaning);
   }
   // A rule set exists for this auction but none of its rules fit the hand
   // (a coverage hole, e.g. a hand too strong for every listed response).
   // Let the heuristic fallback bidder act rather than passing blindly.
   final fb = fallbackBid(hand, history);
-  return SaycBid(
-      fb.action, BidMeaning(description: "No rule matched; ${fb.meaning.description}"));
+  return _legalized(
+      SaycBid(fb.action,
+          BidMeaning(description: "No rule matched; ${fb.meaning.description}")),
+      history);
 }
 
 /// What `call` would show in this auction, independent of any hand. Returns

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -1519,13 +1519,22 @@ List<SaycRule>? twoClubRebidRules(BidAction response) {
           balanced: true),
     ),
     SaycRule(
+      BidAction.noTrump(4),
+      BidMeaning(
+          description: "28-30 HCP, balanced",
+          hcp: const Range(low: 28, high: 30),
+          balanced: true),
+      ignoreInfo: true,
+      require: (h) => h.isBalanced && h.hcp >= 28,
+    ),
+    SaycRule(
       BidAction.noTrump(3),
       BidMeaning(
           description: "25-27 HCP, balanced",
           hcp: const Range(low: 25, high: 27),
           balanced: true),
       ignoreInfo: true,
-      require: (h) => h.isBalanced,
+      require: (h) => h.isBalanced && h.hcp <= 27,
     ),
   ];
   final responseBid = ContractBid(2, Suit.diamonds);
@@ -2181,7 +2190,9 @@ List<SaycRule>? _responderRebidAfter1ntRules(
             suitLengths: {major: const Range(low: 4)},
           ),
           ignoreInfo: true,
-          require: (h) => h.count(major) >= 4,
+          // The invitational raise above catches 8-9 in normal auctions,
+          // but an abnormal opener rebid can make it illegal.
+          require: (h) => h.count(major) >= 4 && h.hcp >= 10,
         ),
       ]);
     }
@@ -2216,6 +2227,9 @@ List<SaycRule>? _responderRebidAfter1ntRules(
             description: "To play, no major-suit fit",
             hcp: const Range(low: 10, high: 15)),
         ignoreInfo: true,
+        // The invitational rungs below 3NT catch 8-9 in normal auctions,
+        // but an abnormal opener rebid can make them illegal.
+        require: (h) => h.hcp >= 10,
       ),
     ]);
     return rules;
@@ -2289,6 +2303,9 @@ List<SaycRule>? _responderRebidAfter1ntRules(
           suitLengths: {major: const Range(low: 5, high: 5)},
         ),
         ignoreInfo: true,
+        // The invitational rungs above catch 8-9 in normal auctions, but
+        // interference can make them illegal.
+        require: (h) => h.hcp >= 10,
       ),
     ];
   }
@@ -2318,6 +2335,22 @@ List<SaycRule>? _responderRebidAfter2cRules(
         BidAction.pass(),
         BidMeaning(
             description: "Bust hand, no game", hcp: const Range(high: 2)),
+      ),
+    ];
+  }
+  if (rebid == BidAction.noTrump(4)) {
+    // 28-30 balanced.
+    return [
+      SaycRule(
+        BidAction.noTrump(6),
+        BidMeaning(
+            description: "Raising to slam opposite 28-30",
+            hcp: const Range(low: 5)),
+      ),
+      SaycRule(
+        BidAction.pass(),
+        BidMeaning(
+            description: "Nothing useful for slam", hcp: const Range(high: 4)),
       ),
     ];
   }
@@ -2686,7 +2719,9 @@ List<SaycRule> _responderRebidAfterSuitRules(
               suitLengths: {oSuit: const Range(low: 2)},
             ),
             ignoreInfo: true,
-            require: (h) => h.count(oSuit) >= 2,
+            // The stronger rungs above only exist below the four level, so
+            // cap this to what it advertises.
+            require: (h) => h.count(oSuit) >= 2 && h.totalPoints <= 6,
           ),
           // No fit and no tolerance: 3NT is the least bad forced call.
           if (cheapestLevel(null, rebid) <= 3)
@@ -3666,8 +3701,11 @@ List<SaycRule> _oneSuitOpenerThirdRules(
     return defaultRules;
   }
   if (responseBid.trump != null && rebidBid.trump == responseBid.trump) {
-    // We raised responder's suit.
-    final single = rebidBid.count == responseBid.count + 1;
+    // We raised responder's suit — or, when the "response" was a raise of
+    // our own opened suit, we re-raised, which shows 16-18 rather than a
+    // single raise's 13-15.
+    final single =
+        rebidBid.count == responseBid.count + 1 && responseBid.trump != oSuit;
     final threshold = single ? 14 : 17;
     final shown =
         single ? const Range(low: 13, high: 15) : const Range(low: 16, high: 18);
@@ -3746,6 +3784,14 @@ List<SaycRule> _oneSuitOpenerThirdRules(
   }
   if (r2 == ContractBid.noTrump(1)) {
     return [
+      SaycRule(
+        BidAction.noTrump(3),
+        BidMeaning(
+            description: "Bidding game opposite the notrump preference",
+            totalPoints: const Range(low: 19)),
+        ignoreInfo: true,
+        require: (h) => h.totalPoints >= 19,
+      ),
       SaycRule(
         BidAction.noTrump(2),
         BidMeaning(

--- a/lib/bridge/sayc/selfplay.dart
+++ b/lib/bridge/sayc/selfplay.dart
@@ -35,6 +35,9 @@ const hardFailureCategories = {
 };
 
 const _maxCalls = 40;
+// Injected chaos calls never pass, so legitimate fuzzed auctions can run
+// well past the engine-only limit before three passes appear.
+const _chaosMaxCalls = 100;
 
 List<List<PlayingCard>> dealHands(int seed, int index) {
   final rng = Random(seed * 100003 + index);
@@ -57,8 +60,9 @@ class SelfPlayFinding {
 class SelfPlayResult {
   final List<BidAction> history;
   final List<SelfPlayFinding> findings;
+  final int injectedCalls;
 
-  SelfPlayResult(this.history, this.findings);
+  SelfPlayResult(this.history, this.findings, [this.injectedCalls = 0]);
 }
 
 String _fmt(List<BidAction> history) =>
@@ -195,16 +199,53 @@ void _lintResult(List<List<PlayingCard>> hands, List<BidAction> history,
 
 int highCardPointsOf(List<PlayingCard> hand) => HandAnalysis(hand).hcp;
 
-SelfPlayResult runDeal(List<List<PlayingCard>> hands) {
+/// A random legal non-pass call for fuzzing: usually a legal double/redouble
+/// or one of the few cheapest contract bids, occasionally anything legal.
+BidAction randomLegalCall(Random rng, List<BidAction> history) {
+  final contracts = <BidAction>[
+    for (int level = 1; level <= 7; level++)
+      for (final trump in [...Suit.values, null])
+        if (isLegalCall(BidAction.contract(level, trump), history))
+          BidAction.contract(level, trump)
+  ];
+  contracts.sort((a, b) =>
+      a.contractBid!.isHigherThan(b.contractBid!) ? 1 : -1);
+  final candidates = <BidAction>[
+    if (isLegalCall(BidAction.double(), history)) BidAction.double(),
+    if (isLegalCall(BidAction.redouble(), history)) BidAction.redouble(),
+    ...(rng.nextDouble() < 0.1 ? contracts : contracts.take(8)),
+  ];
+  if (candidates.isEmpty) return BidAction.pass();
+  return candidates[rng.nextInt(candidates.length)];
+}
+
+/// Runs one auction. With `chaosRng` set, each call is replaced with a
+/// random legal call with probability `chaosProbability`, fuzzing the
+/// engine's responses to auctions it would never produce itself; injected
+/// calls carry no meaning and are exempt from the lints.
+SelfPlayResult runDeal(List<List<PlayingCard>> hands,
+    {Random? chaosRng, double chaosProbability = 0}) {
   final history = <BidAction>[];
   final findings = <SelfPlayFinding>[];
-  while (history.length < _maxCalls) {
+  int injectedCalls = 0;
+  // Seats that have had a call injected: their later engine calls are
+  // premised on bids their hand never justified, so the advertisement
+  // lints don't apply to them.
+  final injectedSeats = <int>{};
+  final maxCalls = chaosRng == null ? _maxCalls : _chaosMaxCalls;
+  while (history.length < maxCalls) {
     final seat = history.length % 4;
     if (history.length >= 4 &&
         history
             .sublist(history.length - 3)
             .every((c) => c.bidType == BidType.pass)) {
       break;
+    }
+    if (chaosRng != null && chaosRng.nextDouble() < chaosProbability) {
+      history.add(randomLegalCall(chaosRng, history));
+      injectedCalls++;
+      injectedSeats.add(seat);
+      continue;
     }
     BidAction call;
     BidMeaning? meaning;
@@ -226,8 +267,10 @@ SelfPlayResult runDeal(List<List<PlayingCard>> hands) {
       meaning = null;
     }
     if (meaning != null) {
-      _lintAdvertisement(
-          HandAnalysis(hands[seat]), seat, call, meaning, history, findings);
+      if (!injectedSeats.contains(seat)) {
+        _lintAdvertisement(
+            HandAnalysis(hands[seat]), seat, call, meaning, history, findings);
+      }
       // Not a failure, but worth monitoring: a rule set existed for this
       // auction but no rule matched the hand, so the fallback bidder acted.
       if (meaning.description.startsWith("No rule matched")) {
@@ -245,11 +288,11 @@ SelfPlayResult runDeal(List<List<PlayingCard>> hands) {
       }
     }
     history.add(call);
-    if (history.length >= _maxCalls) {
+    if (history.length >= maxCalls) {
       findings.add(SelfPlayFinding("runaway-auction", _fmt(history)));
       break;
     }
   }
   _lintResult(hands, history, findings);
-  return SelfPlayResult(history, findings);
+  return SelfPlayResult(history, findings, injectedCalls);
 }

--- a/lib/bridge/sayc/selfplay.dart
+++ b/lib/bridge/sayc/selfplay.dart
@@ -44,31 +44,6 @@ List<List<PlayingCard>> dealHands(int seed, int index) {
 
 int _gameLevel(Suit? trump) => trump == null ? 3 : (isMajorSuit(trump) ? 4 : 5);
 
-bool isLegalCall(BidAction call, List<BidAction> history) {
-  int? lastBidIndex;
-  for (int i = history.length - 1; i >= 0; i--) {
-    if (history[i].bidType == BidType.contract) {
-      lastBidIndex = i;
-      break;
-    }
-  }
-  if (call.bidType == BidType.pass) return true;
-  final n = history.length;
-  if (call.bidType == BidType.contract) {
-    if (lastBidIndex == null) return true;
-    return call.contractBid!.isHigherThan(history[lastBidIndex].contractBid!);
-  }
-  if (lastBidIndex == null) return false;
-  final since = history.sublist(lastBidIndex + 1);
-  final doubled = since.any((c) => c.bidType == BidType.double);
-  final redoubled = since.any((c) => c.bidType == BidType.redouble);
-  final bidByOpponents = (n - lastBidIndex) % 2 == 1;
-  if (call.bidType == BidType.double) {
-    return bidByOpponents && !doubled && !redoubled;
-  }
-  return !bidByOpponents && doubled && !redoubled; // redouble
-}
-
 class SelfPlayFinding {
   final String category;
   final String message;

--- a/scripts/bidding_audit.dart
+++ b/scripts/bidding_audit.dart
@@ -4,13 +4,21 @@
 /// meaning ranges).
 ///
 ///   dart run scripts/bidding_audit.dart [--deals N] [--seed N] [--category X]
+///       [--chaos P]
+///
+/// With --chaos, each call is replaced by a random legal call with
+/// probability P, fuzzing the engine's responses to auctions it would
+/// never produce itself.
 library;
+
+import 'dart:math';
 
 import 'package:cards_with_cats/bridge/sayc/selfplay.dart';
 
 void main(List<String> args) {
   int deals = 2000;
   int seed = 1;
+  double chaos = 0;
   String? category;
   for (int i = 0; i < args.length; i++) {
     switch (args[i]) {
@@ -20,12 +28,18 @@ void main(List<String> args) {
         seed = int.parse(args[++i]);
       case "--category":
         category = args[++i];
+      case "--chaos":
+        chaos = double.parse(args[++i]);
     }
   }
   final counts = <String, int>{};
   final examples = <String, List<String>>{};
+  int injected = 0;
   for (int i = 0; i < deals; i++) {
-    final result = runDeal(dealHands(seed, i));
+    final result = runDeal(dealHands(seed, i),
+        chaosRng: chaos > 0 ? Random(seed * 31 + i) : null,
+        chaosProbability: chaos);
+    injected += result.injectedCalls;
     for (final f in result.findings) {
       if (category != null && f.category != category) continue;
       // Group by category plus the rule description in trailing brackets.
@@ -44,5 +58,6 @@ void main(List<String> args) {
     }
   }
   print("\ntotal: ${counts.values.fold(0, (a, b) => a + b)} findings "
-      "over $deals deals");
+      "over $deals deals"
+      "${chaos > 0 ? ' ($injected chaos calls injected)' : ''}");
 }

--- a/scripts/bridge_play_compare.dart
+++ b/scripts/bridge_play_compare.dart
@@ -28,7 +28,7 @@ import 'package:cards_with_cats/bridge/bridge.dart';
 import 'package:cards_with_cats/bridge/bridge_ai.dart';
 import 'package:cards_with_cats/bridge/play_strategies.dart';
 import 'package:cards_with_cats/bridge/sayc/sayc_bidding.dart';
-import 'package:cards_with_cats/bridge/sayc/selfplay.dart' show isLegalCall;
+import 'package:cards_with_cats/bridge/sayc/sayc_bidding.dart' show isLegalCall;
 
 class StrategyStats {
   int cardsPlayed = 0;

--- a/scripts/bridge_play_compare.dart
+++ b/scripts/bridge_play_compare.dart
@@ -28,7 +28,6 @@ import 'package:cards_with_cats/bridge/bridge.dart';
 import 'package:cards_with_cats/bridge/bridge_ai.dart';
 import 'package:cards_with_cats/bridge/play_strategies.dart';
 import 'package:cards_with_cats/bridge/sayc/sayc_bidding.dart';
-import 'package:cards_with_cats/bridge/sayc/sayc_bidding.dart' show isLegalCall;
 
 class StrategyStats {
   int cardsPlayed = 0;

--- a/scripts/lead_scan.dart
+++ b/scripts/lead_scan.dart
@@ -12,7 +12,6 @@ import 'package:cards_with_cats/bridge/bridge.dart';
 import 'package:cards_with_cats/bridge/bridge_ai.dart';
 import 'package:cards_with_cats/bridge/heuristic_play.dart';
 import 'package:cards_with_cats/bridge/sayc/sayc_bidding.dart';
-import 'package:cards_with_cats/bridge/sayc/selfplay.dart' show isLegalCall;
 import 'package:cards_with_cats/cards/card.dart';
 import 'package:cards_with_cats/cards/rollout.dart';
 

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -962,6 +962,27 @@ void main() {
       expect(openingBid("AKJ32", "432", "K32", "K2", history: ask), "5D");
     });
 
+    test("responder answers Blackwood directly over the Jacoby raise", () {
+      // Opener skipped the shape-showing rebid and asked immediately; this
+      // used to fall into "returning to game" and bid an illegal 4H.
+      final ask = ["1H", "pass", "2NT", "pass", "4NT", "pass"];
+      expect(openingBid("AK43", "AK32", "T54", "32", history: ask), "5H");
+      expect(openingBid("A543", "KQ32", "K54", "K2", history: ask), "5D");
+      expect(
+          openingBid("AK43", "AK32", "T54", "32",
+              history: [...ask, "5H", "pass", "6H", "pass"]),
+          "Pass");
+    });
+
+    test("rules whose action is no longer legal are skipped", () {
+      // A human opener's 5D leaves no legal 4H or 4NT; the engine must not
+      // choose an illegal call.
+      expect(
+          openingBid("AK43", "AK32", "T54", "32",
+              history: ["1H", "pass", "2NT", "pass", "5D", "pass"]),
+          "Pass");
+    });
+
     test("Blackwood placement", () {
       expect(
           openingBid("K432", "A432", "AK2", "K2", history: [

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -998,6 +998,27 @@ void main() {
           "5S"); // zero aces + one shown
     });
 
+    test("2C rebid with 28-30 balanced is 4NT, raised to slam with 5+", () {
+      expect(
+          openingBid("AKQ2", "AKQ", "AK2", "K32",
+              history: ["2C", "pass", "2D", "pass"]),
+          "4NT");
+      expect(
+          openingBid("5432", "T932", "Q54", "K2",
+              history: ["2C", "pass", "2D", "pass", "4NT", "pass"]),
+          "6NT");
+      expect(
+          openingBid("5432", "T932", "654", "32",
+              history: ["2C", "pass", "2D", "pass", "4NT", "pass"]),
+          "Pass");
+    });
+
+    test("opener bids game over the notrump preference with 19+", () {
+      final h = ["1C", "pass", "1D", "pass", "1S", "pass", "1NT", "pass"];
+      expect(openingBid("AJ32", "KQ4", "AQ54", "A2", history: h), "3NT"); // 20
+      expect(openingBid("AJ32", "K54", "AQ54", "A2", history: h), "2NT"); // 18
+    });
+
     test("Gerber answers and continuation", () {
       final ask = ["1NT", "pass", "4C", "pass"];
       expect(openingBid("K32", "A32", "AQ32", "KJ2", history: ask), "4S");

--- a/test/bridge/sayc_fuzz_test.dart
+++ b/test/bridge/sayc_fuzz_test.dart
@@ -1,0 +1,27 @@
+/// Fuzzes the SAYC engine by injecting random legal calls into self-play
+/// auctions: whatever nonsense a partner or opponent produces, the engine
+/// must respond legally, without exceptions, and only with bids whose
+/// advertised meaning its hand actually satisfies.
+import "dart:math";
+
+import "package:cards_with_cats/bridge/sayc/selfplay.dart";
+import "package:flutter_test/flutter_test.dart";
+
+void main() {
+  test("engine stays legal and consistent under injected chaos calls", () {
+    int injected = 0;
+    for (int i = 0; i < 500; i++) {
+      final result = runDeal(dealHands(20260821, i),
+          chaosRng: Random(31 * i + 7), chaosProbability: 0.15);
+      injected += result.injectedCalls;
+      final hard = result.findings
+          .where((f) => hardFailureCategories.contains(f.category))
+          .toList();
+      expect(hard, isEmpty,
+          reason: "deal $i, auction: ${result.history.join(' ')}\n"
+              "${hard.join('\n')}");
+    }
+    // The fuzz should actually have exercised unusual auctions.
+    expect(injected, greaterThan(500));
+  });
+}


### PR DESCRIPTION
- Added a check that every bid the AI makes is legal. Added a fuzzing option to selfplay.dart that injects random but legal bids to verify
- Fixed specific bug where 1H-2NT-4NT wasn't recognized as Blackwood (and without the above check responder "returned" to an illegal 4H)
