### PR TITLE
Bidding improvements

### DIFF
--- a/lib/bridge/sayc/README.md
+++ b/lib/bridge/sayc/README.md
@@ -301,8 +301,8 @@ consulted.
 ## Tools
 
 ```sh
-flutter test test/bridge/sayc_bidding_test.dart   # 180 tests, includes a
-                                                  # 150-deal self-play invariant
+flutter test test/bridge/                         # 312 tests, includes a
+                                                  # 500-deal chaos fuzz test
 
 # Choose or interpret bids from the command line:
 dart run scripts/bridge_cli.dart "A2 AKJT Q32 9876" "1H pass"
@@ -310,8 +310,46 @@ dart run scripts/bridge_cli.dart "1D 1S" --describe X
 dart run scripts/bridge_cli.dart "1S pass 2S pass 3S" --explain
 
 # Self-play over random deals (reproducible from seed + index): reports
-# hard failures (exceptions, illegal calls, runaway auctions, bids below
-# their own advertised minimums — all held at zero) and heuristic quality
-# flags (thin/missed games, bad trump fits, light slams):
-dart run scripts/bridge_selfplay.dart --deals 2000 --seed 7 [--category missed-game]
+# hard failures (exceptions, illegal calls, runaway auctions, bids outside
+# their own advertised ranges — all held at zero) and heuristic quality
+# flags (thin/missed games, bad trump fits, light slams). bridge_selfplay
+# prints per-deal detail (hands + auction); bidding_audit groups the same
+# findings by category and rule for scanning at volume:
+dart run scripts/bridge_selfplay.dart --deals 2000 --seed 7 [--examples 5] \
+    [--category missed-game]
+dart run scripts/bidding_audit.dart --deals 4000 --seed 42 [--category X]
+
+# Fuzzing: replace calls with random legal ones at probability P, checking
+# that the engine responds to auctions it would never produce itself
+# legally, without exceptions, and with honest advertised meanings:
+dart run scripts/bidding_audit.dart --deals 5000 --chaos 0.15
+
+# Bidding accuracy against double-dummy truth (needs cpp/build_libdds.sh):
+DDS_LIB=native/libdds.dylib dart run scripts/bidding_accuracy.dart --deals 1200
 ```
+
+### Audit conventions and current results (2026-08-21)
+
+Seed 1 over 3000 deals is the held-out **test set**: fixes are mined from
+other seeds (42 at 4000 deals is the current dev seed) so that seed 1 stays
+an untouched before/after comparison. Findings there are expected to drift
+down as gaps get fixed; a jump up means a regression.
+
+| Run | Result |
+| --- | --- |
+| seed 1, 3000 deals (test set) | 645 findings, 0 hard failures |
+| seed 42, 4000 deals (dev) | 895 findings, 0 hard failures |
+| chaos 0.15, 5000 deals | 0 hard failures |
+
+Seed 1 findings by category: fallback-used 425, missed-game 142,
+silly-strain 51, missed-slam 25, thin-game 1, no-rule-matched 1. The
+missed-game lint excuses stops below game when an opponent-bid suit is
+unstopped, there is no eight-card major fit, and the side holds under 28
+points (no game is attractive there); missed-slam mostly reflects the
+deliberately minimal slam machinery.
+
+Double-dummy accuracy (1200 deals): games bid make 73.2% of the time
+(precision), and 61.8% of double-dummy-makeable games get bid (recall);
+slams are 3/4 bid-and-making with 1.9% recall of the 161 DD slam chances —
+most DD "slams" lack the combined strength any bidding system would need
+(only 24 of the 161 have 31+ combined HCP).

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -1581,6 +1581,48 @@ List<SaycRule> _oneSuitRebidRules(ContractBid opening, ContractBid response,
     return _rebidAfterRaiseRules(opening, response);
   }
   if (response.trump == null && response.count == 2) {
+    if (contested) {
+      // In competition 2NT is a natural invite (11-12), not Jacoby and not
+      // the 13-15 balanced minor response; accept with 14+.
+      return [
+        if (_isMajor(mySuit))
+          SaycRule(
+            BidAction.contract(4, mySuit),
+            BidMeaning(
+              description: "Accepting the invitation with a 6+ suit",
+              totalPoints: const Range(low: 14),
+              suitLengths: {mySuit: const Range(low: 6)},
+            ),
+            ignoreInfo: true,
+            require: (h) => h.totalPoints >= 14 && h.count(mySuit) >= 6,
+          ),
+        SaycRule(
+          BidAction.noTrump(3),
+          BidMeaning(
+              description: "Accepting the invitation",
+              totalPoints: const Range(low: 14)),
+          ignoreInfo: true,
+          require: (h) => h.totalPoints >= 14,
+        ),
+        SaycRule(
+          BidAction.contract(3, mySuit),
+          BidMeaning(
+            description: "Declining the invitation with a 6+ suit",
+            totalPoints: const Range(high: 13),
+            suitLengths: {mySuit: const Range(low: 6)},
+          ),
+          ignoreInfo: true,
+          require: (h) => h.count(mySuit) >= 6,
+        ),
+        SaycRule(
+          BidAction.pass(),
+          BidMeaning(
+              description: "Declining the invitation",
+              totalPoints: const Range(high: 13)),
+          ignoreInfo: true,
+        ),
+      ];
+    }
     if (_isMajor(mySuit)) {
       // Jacoby 2NT.
       return [
@@ -1786,8 +1828,10 @@ List<SaycRule> _rebidAfter1ntResponseRules(ContractBid opening) {
       BidMeaning(
         description: "Second suit: 4+ ${_suitNames[s]}"
             "${isReverse ? ', reverse showing extra strength' : ''}",
+        // The reverse has no ceiling: hands just below a 2C opening have
+        // no other rebid.
         totalPoints: isReverse
-            ? const Range(low: 17, high: 21)
+            ? const Range(low: 17)
             : const Range(low: 13, high: 17),
         suitLengths: {
           s: const Range(low: 4),
@@ -2670,7 +2714,9 @@ List<SaycRule> _responderRebidAfterSuitRules(
         SaycRule(
           BidAction.noTrump(3),
           BidMeaning(
-              description: "Raising to game", hcp: const Range(low: 7, high: 9)),
+              // The top of the band covers the contested 1NT response,
+              // which shows 6-10 rather than 6-9.
+              description: "Raising to game", hcp: const Range(low: 7, high: 10)),
           ignoreInfo: true,
           require: (h) => h.hcp >= 7,
         ),
@@ -3819,6 +3865,40 @@ List<SaycRule> _oneSuitOpenerThirdRules(
     return inviteRules(
         suitGame(rebidBid.trump!), 15, const Range(low: 13), false);
   }
+  if (rebidBid.trump != null &&
+      rebidBid.trump != oSuit &&
+      r2.trump == oSuit &&
+      r2.count == cheapestLevel(oSuit, rebidBid)) {
+    // Responder gave simple preference to our first suit. After a strong
+    // rebid (a reverse or jump shift, 17+) the preference shows a weak
+    // hand but big hands must still bid on.
+    final strong =
+        rebidBid.count > cheapestLevel(rebidBid.trump!, responseBid) ||
+            _strainOrder(rebidBid.trump!) > _strainOrder(oSuit);
+    if (strong) {
+      final game = _isMajor(oSuit) && r2.count < 4
+          ? BidAction.contract(4, oSuit)
+          : BidAction.noTrump(3);
+      return [
+        if (isLegalCall(game, [BidAction.withBid(r2)]))
+          SaycRule(
+            game,
+            BidMeaning(
+                description: "Bidding game opposite the preference",
+                totalPoints: const Range(low: 20)),
+            ignoreInfo: true,
+            require: (h) => h.totalPoints >= 20,
+          ),
+        SaycRule(
+          BidAction.pass(),
+          BidMeaning(
+              description: "Minimum for the strong rebid",
+              totalPoints: const Range(high: 19)),
+          ignoreInfo: true,
+        ),
+      ];
+    }
+  }
   return defaultRules;
 }
 
@@ -4616,6 +4696,32 @@ List<SaycRule> overcallerNewSuitRebidRules(
         ignoreInfo: true,
         require: (h) => h.hcp >= 11 && h.hasStopper(theirSuit),
       ),
+    for (final s in Suit.values)
+      if (s != mySuit &&
+          s != aSuit &&
+          s != theirSuit &&
+          cheapestLevel(s, advance) <= 2)
+        SaycRule(
+          BidAction.contract(cheapestLevel(s, advance), s),
+          BidMeaning(
+            description: "Second suit: 5+ ${_suitNames[s]}, extra values",
+            totalPoints: const Range(low: 14),
+            suitLengths: {s: const Range(low: 5)},
+          ),
+          ignoreInfo: true,
+          require: (h) =>
+              h.totalPoints >= 14 &&
+              h.count(s) >= 5 &&
+              bestSuit(
+                      h,
+                      Suit.values.where((t) =>
+                          t != mySuit &&
+                          t != aSuit &&
+                          t != theirSuit &&
+                          h.count(t) >= 5 &&
+                          cheapestLevel(t, advance) <= 2)) ==
+                  s,
+        ),
     if (forcing)
       SaycRule(
         BidAction.contract(cheapestLevel(mySuit, advance), mySuit),
@@ -4628,9 +4734,9 @@ List<SaycRule> overcallerNewSuitRebidRules(
     else
       SaycRule(
         BidAction.pass(),
-        BidMeaning(
-            description: "No fit and no descriptive rebid",
-            totalPoints: const Range(high: 16)),
+        // Shape information only: the overcall itself already limited the
+        // hand, and stronger hands with no descriptive rebid also pass.
+        BidMeaning(description: "No fit and no descriptive rebid"),
         ignoreInfo: true,
       ),
   ];
@@ -4732,7 +4838,12 @@ List<SaycRule>? advanceOvercallRules(
         totalPoints: const Range(low: 10),
         suitLengths: {s: const Range(low: 5)},
       ),
-      require: (h) => newSuitChoice(h) == s,
+      // With game values and support for the overcall, the forcing
+      // cue-bid (or game raise) below is preferred to this non-forcing
+      // change of suit, which the overcaller may pass.
+      require: (h) =>
+          newSuitChoice(h) == s &&
+          (h.totalPoints <= 12 || h.count(suit) < 3),
     ));
   }
   final ntLevel = cheapestLevel(null, over);

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -6173,6 +6173,15 @@ List<SaycRule>? saycRulesForAuction(List<BidAction> calls) {
     }
     return null;
   }
+  if (n == first + 4 &&
+      calls[first + 1].bidType == BidType.pass &&
+      calls[first + 2].bidType == BidType.contract &&
+      calls[first + 3].bidType == BidType.double) {
+    // RHO doubled partner's natural response. The double takes away no
+    // bidding space and partner's new suit is still forcing, so rebid
+    // exactly as if there were no interference (systems on).
+    return openerRebidRules(opening, calls[first + 2]);
+  }
   if (n == first + 4 && calls[first + 3].bidType == BidType.pass) {
     final overcall = calls[first + 1];
     final partnerCall = calls[first + 2];

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -4961,8 +4961,37 @@ List<SaycRule> overcallCueRebidRules(ContractBid theirOpening,
 }
 
 /// Responder's call after passing, when partner reopened with a double.
-List<SaycRule> reopeningDoubleAdvanceRules(ContractBid overcall) {
-  return advanceDoubleRules(overcall, overcall, true);
+List<SaycRule> reopeningDoubleAdvanceRules(
+    ContractBid opening, ContractBid overcall) {
+  final base = advanceDoubleRules(overcall, overcall, true);
+  final oSuit = opening.trump;
+  // Only a major opening promises a real (5+) suit worth returning to
+  // with 3-card support; opposite a minor the double's promised suits
+  // rank first and the best-suit logic may still pick a long minor.
+  if (oSuit == null || !_isMajor(oSuit)) return base;
+  final level = cheapestLevel(oSuit, overcall);
+  if (level > 3) return base;
+  // Unlike a direct takeout double, the reopening doubler has shown a real
+  // suit by opening it; with 3+ support prefer the known fit to a possibly
+  // unsupported "best suit" (often at a higher level). Having passed the
+  // opening, the hand is too weak for anything more than the preference.
+  // The penalty pass stays ahead of it.
+  final preference = SaycRule(
+    BidAction.contract(level, oSuit),
+    BidMeaning(
+      description: "Returning to opener's ${_suitNames[oSuit]} with support",
+      totalPoints: const Range(high: 8),
+      suitLengths: {oSuit: const Range(low: 3)},
+    ),
+    ignoreInfo: true,
+    require: (h) => h.count(oSuit) >= 3 && h.totalPoints <= 8,
+  );
+  final passIndex = base.indexWhere((r) => r.action == BidAction.pass());
+  return [
+    ...base.take(passIndex + 1),
+    preference,
+    ...base.skip(passIndex + 1),
+  ];
 }
 
 /// Opener's action in the pass-out seat: we opened, LHO overcalled, partner
@@ -6281,7 +6310,8 @@ List<SaycRule>? saycRulesForAuction(List<BidAction> calls) {
           suitOpening &&
           isSuitBid(rho1) &&
           lho.bidType == BidType.pass) {
-        return reopeningDoubleAdvanceRules(rho1.contractBid!);
+        return reopeningDoubleAdvanceRules(
+            opening.contractBid!, rho1.contractBid!);
       }
     }
     return null;

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -4637,17 +4637,21 @@ List<SaycRule> overcallerNewSuitRebidRules(
         h.count(mySuit) >= 6 &&
         h.topHonorCount(mySuit) >= 2,
   );
+  // Even over a forcing advance, game needs a real fit and a maximum:
+  // the advance is unlimited (10+), so a strong advancer will move again
+  // over any cheaper descriptive rebid, and the forced catch-alls below
+  // guarantee the overcaller has one.
   final gameRaise = SaycRule(
     BidAction.contract(gameLevel, aSuit),
     BidMeaning(
       description: "Raising partner's $aName to game",
-      totalPoints: Range(low: forcing ? 13 : 14),
-      suitLengths: {aSuit: Range(low: forcing ? 2 : 3)},
+      totalPoints: Range(low: _isMajor(aSuit) ? 14 : 15),
+      suitLengths: {aSuit: Range(low: _isMajor(aSuit) ? 3 : 4)},
     ),
     ignoreInfo: true,
     require: (h) =>
-        h.totalPoints >= (forcing ? 13 : 14) &&
-        h.count(aSuit) >= (forcing ? 2 : 3),
+        h.totalPoints >= (_isMajor(aSuit) ? 14 : 15) &&
+        h.count(aSuit) >= (_isMajor(aSuit) ? 3 : 4),
   );
   final nt3 = SaycRule(
     BidAction.noTrump(3),
@@ -4670,7 +4674,11 @@ List<SaycRule> overcallerNewSuitRebidRules(
         BidAction.contract(advance.count + 1, aSuit),
         BidMeaning(
           description: "Raising partner's $aName",
-          totalPoints: const Range(low: 11, high: 13),
+          // Below a major game raise the range is 11-13; a minor raise
+          // also carries maximums that lack the 4th trump for 5m.
+          totalPoints: _isMajor(aSuit)
+              ? const Range(low: 11, high: 13)
+              : const Range(low: 11),
           suitLengths: {aSuit: const Range(low: 3)},
         ),
         ignoreInfo: true,

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -2160,7 +2160,11 @@ List<SaycRule>? responderRebidRules(
 }
 
 List<SaycRule>? _responderRebidAfter1ntRules(
-    BidAction response, BidAction rebid) {
+    BidAction response, BidAction rebid,
+    {int hcpShift = 0}) {
+  // Systems on over a 1NT overcall reuse these rules; opposite the lighter
+  // balancing 1NT (11-16) all strength thresholds rise by `hcpShift`.
+  final int s = hcpShift;
   if (response == BidAction.contract(4, Suit.clubs)) {
     return gerberContinuationRules(rebid);
   }
@@ -2175,24 +2179,25 @@ List<SaycRule>? _responderRebidAfter1ntRules(
         SaycRule(
           BidAction.contract(3, major),
           BidMeaning(
-            description: "Invitational raise: 4 $name, 8-9 HCP",
-            hcp: const Range(low: 8, high: 9),
+            description:
+                "Invitational raise: 4 $name, ${8 + s}-${9 + s} HCP",
+            hcp: Range(low: 8 + s, high: 9 + s),
             suitLengths: {major: const Range(low: 4)},
           ),
           ignoreInfo: true,
-          require: (h) => h.count(major) >= 4 && h.hcp <= 9,
+          require: (h) => h.count(major) >= 4 && h.hcp <= 9 + s,
         ),
         SaycRule(
           BidAction.contract(4, major),
           BidMeaning(
             description: "Raise to game: 4 $name",
-            hcp: const Range(low: 10),
+            hcp: Range(low: 10 + s),
             suitLengths: {major: const Range(low: 4)},
           ),
           ignoreInfo: true,
-          // The invitational raise above catches 8-9 in normal auctions,
-          // but an abnormal opener rebid can make it illegal.
-          require: (h) => h.count(major) >= 4 && h.hcp >= 10,
+          // The invitational raise above catches invitational hands in
+          // normal auctions, but an abnormal rebid can make it illegal.
+          require: (h) => h.count(major) >= 4 && h.hcp >= 10 + s,
         ),
       ]);
     }
@@ -2201,35 +2206,35 @@ List<SaycRule>? _responderRebidAfter1ntRules(
         BidAction.noTrump(2),
         BidMeaning(
             description: "Inviting 3NT, no major-suit fit",
-            hcp: const Range(low: 8, high: 9)),
+            hcp: Range(low: 8 + s, high: 9 + s)),
         ignoreInfo: true,
-        require: (h) => h.hcp <= 9,
+        require: (h) => h.hcp <= 9 + s,
       ),
       SaycRule(
         BidAction.noTrump(6),
         BidMeaning(
-            description: "Slam: 18+ opposite the notrump opening",
-            hcp: const Range(low: 18)),
+            description: "Slam: ${18 + s}+ opposite the notrump",
+            hcp: Range(low: 18 + s)),
         ignoreInfo: true,
-        require: (h) => h.hcp >= 18,
+        require: (h) => h.hcp >= 18 + s,
       ),
       SaycRule(
         BidAction.noTrump(4),
         BidMeaning(
             description: "Quantitative: invites 6NT, no fit",
-            hcp: const Range(low: 16, high: 17)),
+            hcp: Range(low: 16 + s, high: 17 + s)),
         ignoreInfo: true,
-        require: (h) => h.hcp >= 16,
+        require: (h) => h.hcp >= 16 + s,
       ),
       SaycRule(
         BidAction.noTrump(3),
         BidMeaning(
             description: "To play, no major-suit fit",
-            hcp: const Range(low: 10, high: 15)),
+            hcp: Range(low: 10 + s, high: 15 + s)),
         ignoreInfo: true,
-        // The invitational rungs below 3NT catch 8-9 in normal auctions,
-        // but an abnormal opener rebid can make them illegal.
-        require: (h) => h.hcp >= 10,
+        // The invitational rungs below 3NT catch invitational hands in
+        // normal auctions, but an abnormal rebid can make them illegal.
+        require: (h) => h.hcp >= 10 + s,
       ),
     ]);
     return rules;
@@ -2246,21 +2251,21 @@ List<SaycRule>? _responderRebidAfter1ntRules(
         BidAction.pass(),
         BidMeaning(
             description: "Signing off after the transfer",
-            hcp: const Range(high: 7)),
+            hcp: Range(high: 7 + s)),
       ),
       SaycRule(
         BidAction.contract(3, major),
         BidMeaning(
-          description: "Inviting game: 6+ $name, 8-9 HCP",
-          hcp: const Range(low: 8, high: 9),
+          description: "Inviting game: 6+ $name, ${8 + s}-${9 + s} HCP",
+          hcp: Range(low: 8 + s, high: 9 + s),
           suitLengths: {major: const Range(low: 6)},
         ),
       ),
       SaycRule(
         BidAction.noTrump(2),
         BidMeaning(
-          description: "Inviting game: exactly 5 $name, 8-9 HCP",
-          hcp: const Range(low: 8, high: 9),
+          description: "Inviting game: exactly 5 $name, ${8 + s}-${9 + s} HCP",
+          hcp: Range(low: 8 + s, high: 9 + s),
           suitLengths: {major: const Range(low: 5, high: 5)},
         ),
       ),
@@ -2268,44 +2273,44 @@ List<SaycRule>? _responderRebidAfter1ntRules(
         BidAction.contract(4, major),
         BidMeaning(
           description: "To play: 6+ $name, game values",
-          hcp: const Range(low: 10, high: 15),
+          hcp: Range(low: 10 + s, high: 15 + s),
           suitLengths: {major: const Range(low: 6)},
         ),
         ignoreInfo: true,
-        require: (h) => h.count(major) >= 6 && h.hcp <= 15,
+        require: (h) => h.count(major) >= 6 && h.hcp <= 15 + s,
       ),
       SaycRule(
         BidAction.noTrump(6),
         BidMeaning(
-          description: "Slam: 18+ with 5+ $name",
-          hcp: const Range(low: 18),
+          description: "Slam: ${18 + s}+ with 5+ $name",
+          hcp: Range(low: 18 + s),
           suitLengths: {major: const Range(low: 5)},
         ),
         ignoreInfo: true,
-        require: (h) => h.hcp >= 18,
+        require: (h) => h.hcp >= 18 + s,
       ),
       SaycRule(
         BidAction.noTrump(4),
         BidMeaning(
           description: "Quantitative: invites slam with 5+ $name",
-          hcp: const Range(low: 16, high: 17),
+          hcp: Range(low: 16 + s, high: 17 + s),
           suitLengths: {major: const Range(low: 5)},
         ),
         ignoreInfo: true,
-        require: (h) => h.hcp >= 16,
+        require: (h) => h.hcp >= 16 + s,
       ),
       SaycRule(
         BidAction.noTrump(3),
         BidMeaning(
           description:
               "Choice of games: exactly 5 $name, opener corrects with a fit",
-          hcp: const Range(low: 10, high: 15),
+          hcp: Range(low: 10 + s, high: 15 + s),
           suitLengths: {major: const Range(low: 5, high: 5)},
         ),
         ignoreInfo: true,
-        // The invitational rungs above catch 8-9 in normal auctions, but
-        // interference can make them illegal.
-        require: (h) => h.hcp >= 10,
+        // The invitational rungs above catch invitational hands in normal
+        // auctions, but interference can make them illegal.
+        require: (h) => h.hcp >= 10 + s,
       ),
     ];
   }
@@ -5984,6 +5989,28 @@ List<SaycRule>? saycRulesForAuction(List<BidAction> calls) {
         return overcallCueRebidRules(
             openBid, myActions[0].contractBid!, last, last == cue);
       }
+    }
+    if (myActions.length == 1 &&
+        partnerActions.length == 2 &&
+        partnerActions[0] == BidAction.noTrump(1) &&
+        myActions[0].bidType == BidType.contract &&
+        oppActions.length == 1 &&
+        n >= 7 &&
+        calls[n - 1].bidType == BidType.pass &&
+        calls[n - 2].bidType == BidType.contract &&
+        calls[n - 3].bidType == BidType.pass &&
+        calls[n - 4] == myActions[0] &&
+        calls[n - 6] == BidAction.noTrump(1)) {
+      // I responded to partner's 1NT overcall with systems on and partner
+      // answered, the opponents staying silent since their opening bid:
+      // continue as after a 1NT opening, with strength thresholds raised
+      // opposite the lighter balancing 1NT (11-16).
+      final ntIndex = n - 6;
+      final balancing = ntIndex >= 2 &&
+          calls[ntIndex - 1].bidType == BidType.pass &&
+          calls[ntIndex - 2].bidType == BidType.pass;
+      return _responderRebidAfter1ntRules(myActions[0], calls[n - 2],
+          hcpShift: balancing ? 3 : 0);
     }
     if (myActions.length == 1 &&
         myActions[0] == BidAction.noTrump(1) &&

--- a/lib/bridge/sayc/selfplay.dart
+++ b/lib/bridge/sayc/selfplay.dart
@@ -15,6 +15,8 @@
 ///   slam-light       undoubled slam with < 28 combined HCP
 ///   silly-strain     suit contract with <= 6 combined trumps
 ///   missed-game      declaring side with 26+ combined stopped below game
+///                    (excused with an opponent suit unstopped, no major
+///                    fit, and under 28 points: no game is attractive)
 ///   missed-slam      declaring side with 33+ combined HCP (or 36+ total
 ///                    points) stopped below the six level
 ///   passed-out       deal passed out despite 25+ combined points
@@ -180,12 +182,35 @@ void _lintResult(List<List<PlayingCard>> hands, List<BidAction> history,
         "slam-light", "$contract with ${combinedHcp(side)} combined HCP"));
   }
   if (!atGame && !doubled && combinedTotal(side) >= 26) {
-    // Only the declaring side: defenders selling out is a different (and
-    // much harder) judgment problem.
-    findings.add(SelfPlayFinding(
-        "missed-game",
-        "the declaring side has ${combinedTotal(side)} combined points but "
-        "stopped in $contract"));
+    // A partscore can be the right spot despite the points: with an
+    // opponent-bid suit unstopped (3NT unattractive), no eight-card major
+    // fit, and not enough for the five level, stopping in 4C/4D is at
+    // worst unclear, so don't flag it.
+    final oppSuits = {
+      for (int i = 0; i < history.length; i++)
+        if (i % 2 != side &&
+            history[i].bidType == BidType.contract &&
+            history[i].contractBid!.trump != null)
+          history[i].contractBid!.trump!
+    };
+    bool stopped(Suit s) =>
+        HandAnalysis(hands[side]).hasStopper(s) ||
+        HandAnalysis(hands[side + 2]).hasStopper(s);
+    final majorFit = [Suit.hearts, Suit.spades].any((s) =>
+        hands[side].where((c) => c.suit == s).length +
+            hands[side + 2].where((c) => c.suit == s).length >=
+        8);
+    final excused = oppSuits.any((s) => !stopped(s)) &&
+        !majorFit &&
+        combinedTotal(side) < 28;
+    if (!excused) {
+      // Only the declaring side: defenders selling out is a different (and
+      // much harder) judgment problem.
+      findings.add(SelfPlayFinding(
+          "missed-game",
+          "the declaring side has ${combinedTotal(side)} combined points but "
+          "stopped in $contract"));
+    }
   }
   if (contract.count < 6 &&
       !doubled &&

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1372,11 +1372,13 @@ void main() {
           openingBid("AKQT982", "4", "6", "Q874",
               history: ["1C", "1S", "pass", "2H", "pass"]),
           "4S");
-      // Forcing 3-level advance: raise with a doubleton (deal 2338).
+      // Forcing 3-level advance with only a doubleton: no game raise
+      // without a real fit; with their suit stopped and a running suit,
+      // 3NT is the descriptive game try.
       expect(
           openingBid("JT", "62", "Q93", "AKJ632",
               history: ["2D", "3C", "pass", "3S", "pass"]),
-          "4S");
+          "3NT");
       // Forcing minor advance: 3NT with their suit stopped (deal 120).
       expect(
           openingBid("9854", "KJ2", "AJT82", "A",
@@ -1674,6 +1676,15 @@ void main() {
               history: ["1D", "pass", "1NT", "pass", "2H", "pass", "3D",
                   "pass"]),
           "Pass");
+    });
+
+    test("overcaller needs a real fit and maximum to raise the advance to game",
+        () {
+      // Manual-play hand: 13 total with a doubleton raised the unlimited
+      // 3D advance (10+, 5+ diamonds) straight to 5D.
+      final h = ["2H", "3C", "pass", "3D", "pass"];
+      expect(openingBid("K9", "J5", "84", "AKT8754", history: h), "4C");
+      expect(openingBid("K9", "J5", "QJ84", "AKT87", history: h), "5D");
     });
 
     test("reopening-double advance prefers opener's suit with support", () {

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1442,6 +1442,27 @@ void main() {
           "3NT");
     });
 
+    test("advancer continues after the systems-on answer", () {
+      // Self-play deal 53 (seed 1): balancing 1NT, Stayman found the wrong
+      // major; 12 HCP opposite 11-16 invites instead of passing 2H.
+      expect(
+          openingBid("J732", "KT", "AT4", "AT94",
+              history: ["1H", "pass", "pass", "1NT", "pass", "2C", "pass",
+                  "2H", "pass"]),
+          "2NT");
+      // With the 4-4 spade fit found, an invitational raise.
+      expect(
+          openingBid("J732", "KT", "AT4", "AT94",
+              history: ["1H", "pass", "pass", "1NT", "pass", "2C", "pass",
+                  "2S", "pass"]),
+          "3S");
+      // Opposite a direct overcall (15-18) the same hand drives to game.
+      expect(
+          openingBid("J732", "KT", "AT4", "AT94",
+              history: ["1H", "1NT", "pass", "2C", "pass", "2H", "pass"]),
+          "3NT");
+    });
+
     test("1NT overcaller answers systems-on responses", () {
       // Direct overcall: complete the transfer.
       expect(

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1676,6 +1676,17 @@ void main() {
           "Pass");
     });
 
+    test("reopening-double advance prefers opener's suit with support", () {
+      // Manual-play hand: the forced advance bid 3C on four small instead
+      // of returning to the known 5-3 heart fit.
+      final h = ["1H", "2D", "pass", "pass", "X", "pass"];
+      expect(openingBid("Q87", "972", "K54", "8532", history: h), "2H");
+      // The penalty pass still comes first with a diamond stack.
+      expect(openingBid("Q87", "972", "KQJT8", "85", history: h), "Pass");
+      // Without support, the best-suit advance stands.
+      expect(openingBid("Q87", "97", "K54", "85432", history: h), "3C");
+    });
+
     test("overcaller shows a second suit over the new-suit advance", () {
       // Self-play deal 3606 (seed 42): 5-5 with 17 total passed the 2C
       // advance with "no descriptive rebid".

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1649,6 +1649,54 @@ void main() {
 
   group("fallback bidder", () {
 
+    test("2NT over an overcall is answered as a natural invite", () {
+      // Self-play deal 44 (seed 42): opener read the natural 11-12 2NT as
+      // Jacoby and signed off in 3H with 17 total.
+      expect(openingBid("T6", "AKQ643", "J", "AJT2",
+              history: ["1H", "2D", "2NT", "pass"]),
+          "4H");
+      expect(openingBid("T6", "KQJ643", "J2", "QT2",
+              history: ["1H", "2D", "2NT", "pass"]),
+          "3H");
+      expect(openingBid("T63", "KQJ64", "J2", "QT2",
+              history: ["1H", "2D", "2NT", "pass"]),
+          "Pass");
+    });
+
+    test("opener bids on over a weak preference after a reverse", () {
+      // Self-play deal 58 (seed 42): 22 total passed partner's 3D
+      // preference to the reverse.
+      expect(openingBid("KQ4", "AKT5", "AJ942", "A",
+              history: ["1D", "pass", "1NT", "pass", "2H", "pass", "3D",
+                  "pass"]),
+          "3NT");
+      expect(openingBid("K4", "AKT5", "AJ942", "84",
+              history: ["1D", "pass", "1NT", "pass", "2H", "pass", "3D",
+                  "pass"]),
+          "Pass");
+    });
+
+    test("overcaller shows a second suit over the new-suit advance", () {
+      // Self-play deal 3606 (seed 42): 5-5 with 17 total passed the 2C
+      // advance with "no descriptive rebid".
+      expect(openingBid("KT732", "KQ742", "K", "A2",
+              history: ["pass", "1D", "1S", "pass", "2C", "pass"]),
+          "2H");
+    });
+
+    test("game-values advance with support cue-bids instead of a new suit",
+        () {
+      // Self-play deal 55 (seed 42): 16 total made an unlimited 1H advance
+      // the overcaller could (and did) pass.
+      expect(openingBid("A652", "KQT32", "AJ7", "J",
+              history: ["1C", "1D", "pass"]),
+          "2C");
+      // Without game values the new suit is still right.
+      expect(openingBid("A652", "KQT32", "J7", "J8",
+              history: ["1C", "1D", "pass"]),
+          "1H");
+    });
+
     test("balancing 1NT continuations use the lighter range", () {
       final stayman = ["1C", "pass", "pass", "1NT", "pass", "2C", "pass"];
       expect(openingBid("KJ3", "K643", "543", "AJT", history: stayman), "2H");

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1238,6 +1238,14 @@ void main() {
           "3NT"); // 13 with a spade stopper
     });
 
+    test("opener rebids over RHO's double of partner's response", () {
+      // A double takes away no bidding space, so systems are on.
+      final h = ["1C", "pass", "1H", "X"];
+      expect(openingBid("AQ8", "Q842", "8", "KQ643", history: h), "2H");
+      expect(openingBid("AQ84", "K8", "84", "KQ843", history: h), "1S");
+      expect(openingBid("AQ8", "K84", "QJ4", "K843", history: h), "1NT");
+    });
+
     test("opener rebids over partner's response to a takeout double", () {
       // Playtest hand: 1H was forcing but opener passed via the fallback.
       expect(


### PR DESCRIPTION
- Fix opener passing partner's response when RHO doubles
- Fix advancer passing the Stayman answer after a 1NT overcall
- Support opener's major suit after reopening double
- Fix 2NT after overcall interpreted as Jacoby 2NT raise
- Avoid overly optimistic minor suit games
- Document selfplay audit, and allow "missing" 27 point games with no major fit and no stoppers in opponent suits