### PR TITLE
Enable the DDS solver backend for Linux desktop builds

### DIFF
--- a/cpp/build_libdds.sh
+++ b/cpp/build_libdds.sh
@@ -9,8 +9,9 @@
 # DDS_SRC to point at another checkout). The output is gitignored. App
 # builds run this automatically: the macOS Runner's "Embed libdds"
 # phase invokes it when sources are newer than the dylib, and Android
-# compiles the same sources itself via android/app/CMakeLists.txt. Run
-# manually only for command-line use (DDS_LIB=native/libdds.dylib).
+# and Linux compile the same sources themselves via
+# android/app/CMakeLists.txt and linux/CMakeLists.txt. Run manually
+# only for command-line use (DDS_LIB=native/libdds.dylib).
 set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/lib/bridge/dds_ffi.dart
+++ b/lib/bridge/dds_ffi.dart
@@ -3,7 +3,9 @@
 /// the library with cpp/build_libdds.sh; it is loaded
 /// from the platform default location when present (macOS: bundled in
 /// Contents/Frameworks by a Runner build phase; Android: libdds.so from
-/// jniLibs), and the DDS_LIB environment variable overrides the path for
+/// jniLibs; Linux: libdds.so from the bundle's lib/ directory, built by
+/// linux/CMakeLists.txt), and the DDS_LIB environment variable overrides
+/// the path for
 /// development. When no library can be loaded, callers fall back to the
 /// pure-Dart DDSolver. Each isolate loads independently.
 ///
@@ -99,6 +101,12 @@ class DdsBackend {
       } else if (Platform.isMacOS) {
         final path = "${File(Platform.resolvedExecutable).parent.path}"
             "/../Frameworks/libdds.dylib";
+        if (File(path).existsSync()) {
+          _instance = _tryLoad(path, verbose: false);
+        }
+      } else if (Platform.isLinux) {
+        final path = "${File(Platform.resolvedExecutable).parent.path}"
+            "/lib/libdds.so";
         if (File(path).existsSync()) {
           _instance = _tryLoad(path, verbose: false);
         }

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -68,6 +68,20 @@ set_target_properties(${BINARY_NAME}
 # them to the application.
 include(flutter/generated_plugins.cmake)
 
+# Build the dds double-dummy solver (vendored in third_party/dds, plus our
+# isolate-safety shim in cpp/) as libdds.so, mirroring
+# android/app/CMakeLists.txt. It is installed into the bundle's lib/
+# directory below and loaded via Dart FFI by lib/bridge/dds_ffi.dart.
+# Third-party code, so it doesn't get apply_standard_settings' -Werror.
+set(REPO_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/..")
+file(GLOB DDS_SOURCES "${REPO_ROOT}/third_party/dds/src/*.cpp")
+add_library(dds SHARED ${DDS_SOURCES} "${REPO_ROOT}/cpp/dds_shim.cpp")
+target_include_directories(dds PRIVATE
+  "${REPO_ROOT}/third_party/dds/include"
+  "${REPO_ROOT}/third_party/dds/src")
+target_compile_definitions(dds PRIVATE DDS_THREADS_STL)
+target_compile_options(dds PRIVATE -O2)
+
 
 # === Installation ===
 # By default, "installing" just makes a relocatable bundle in the build
@@ -99,6 +113,9 @@ if(PLUGIN_BUNDLED_LIBRARIES)
     DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
     COMPONENT Runtime)
 endif()
+
+install(TARGETS dds LIBRARY DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+  COMPONENT Runtime)
 
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.


### PR DESCRIPTION
Verified that the dds library loads when run with `flutter run -d linux --release`