### PR TITLE
Fix SAYC bidding bugs and gaps found by adversarial review

### DIFF
--- a/lib/bridge/sayc/README.md
+++ b/lib/bridge/sayc/README.md
@@ -148,8 +148,9 @@ consulted.
   the preempt suit, and responder then bids game with 17+ opposite the
   raise or retreats to a self-sufficient 6+ suit. Over 3-level preempts:
   game with 15+ and a fit (over a major); over a minor preempt 3NT needs
-  only 15 with 3+ trumps (partner's suit will run), 16 without, and a
-  17+ hand with 4+ trumps raises to five.
+  the side suits stopped (15 with 3+ trumps — partner's suit supplies the
+  tricks — or 16 without), and game values (16+) with 3+ trumps but an
+  unstopped suit raise to five instead.
 
 ### Opener rebids
 - After a new-suit response: raise partner's major with 4 trumps (13-15

--- a/lib/bridge/sayc/README.md
+++ b/lib/bridge/sayc/README.md
@@ -143,16 +143,25 @@ consulted.
   2D waiting otherwise.
 - To weak twos: preemptive raise with 3+ trumps, game with 15+ and 3+
   trumps or 16+ and a doubleton (the 8-card fit beats 3NT), 3NT to play
-  with 16+ and no fit; otherwise pass. Over 3-level preempts: game with 15+
-  and a fit, 3NT with 16+.
+  with 16+ and no fit, and a new suit below game (RONF) = good 5+ suit
+  with 15+, forcing one round: opener raises with 3+ support, else rebids
+  the preempt suit, and responder then bids game with 17+ opposite the
+  raise or retreats to a self-sufficient 6+ suit. Over 3-level preempts:
+  game with 15+ and a fit (over a major); over a minor preempt 3NT needs
+  only 15 with 3+ trumps (partner's suit will run), 16 without, and a
+  17+ hand with 4+ trumps raises to five.
 
 ### Opener rebids
 - After a new-suit response: raise partner's major with 4 trumps (13-15
-  single, 16-18 jump, 19+ game); over a minor response show a 4-card major
-  first; NT rebids show 12-14 (cheapest) or 18-19 (jump) balanced; 6-card
-  suit rebids (13-15 cheap, 16+ jump); second suits at the cheapest level,
-  with reverses requiring 17+ and jump shifts showing 18+; otherwise rebid
-  the suit.
+  single, 16-18 jump, 19+ game) — 3 trumps suffice for the 2H response to
+  1S, which promised five; over a minor response show a 4-card major
+  first; over a minor two-over-one, 16-18 with a fit and the unbid suits
+  stopped bids 3NT rather than the four-level jump raise; NT rebids show
+  12-14 (cheapest) or 18-19 (jump) balanced; 6-card suit rebids (13-15
+  cheap, 16+ jump); second suits at the cheapest level, with reverses
+  requiring 17+ and jump shifts showing 18+; otherwise rebid the suit.
+  A 3NT response to a minor (16+ balanced) is raised to 6NT with 17+
+  (33+ combined is certain).
 - After raises: pass minimums, invite with 16-18, bid game with 19+ (accept
   a limit raise with 14+).
 - After Jacoby 2NT: 4M minimum, 3M with extras.
@@ -173,7 +182,9 @@ consulted.
 - 1NT auctions: raise Stayman-found fits (invite 8-9, game 10+), retreat to
   2NT/3NT without a fit; after a transfer, pass 0-7, invite with 8-9 (2NT
   with five trumps, 3M with six), and bid game with 10+ (3NT choice-of-games
-  with five trumps, 4M with six).
+  with five trumps, 4M with six). With six or more trumps the fit is known,
+  so the suit rungs count total points (length included) while the notrump
+  rungs stay in HCP — a 7-HCP hand with a seven-card suit bids game.
 - After opener raises responder's suit: pass 6-10, invite 11-12, game 13+;
   over a jump raise, game with 8+.
 - After opener's 1NT rebid: pass 6-10, 2NT invite 11-12, 3NT 13+, with
@@ -207,8 +218,16 @@ consulted.
 - Blackwood 4NT after suit agreement (currently launched from Jacoby 2NT
   sequences: 16+ opposite extras, 18+ opposite a minimum): answers
   5C/5D/5H/5S = 0-4/1/2/3 aces; the asker bids six missing at most one ace,
-  else stops at five. No 5NT king-ask or grand-slam machinery; the ambiguous
-  0-or-4 answers are disambiguated from the asker's own aces.
+  else stops at five — passing when the answer itself is five of the trump
+  suit. No 5NT king-ask or grand-slam machinery. An asker with an ace
+  reads the ambiguous 0-or-4 answer as 0 (only four exist); an ace-less
+  asker reads it as 4 — for both hands to be ace-less, the partnership
+  would need essentially all 24 non-ace HCP plus freak shape while the
+  silent opponents held the four aces and a huge fit, and a human partner
+  answering 5C far more plausibly shaded a strength cap holding all four.
+  2C auctions also raise directly to 6NT on proven
+  strength: 11+ opposite the opener's suit rebid, and the opener raises
+  responder's 3NT retreat with 25+ opposite a positive (8+).
 
 ### Opener's third call
 - Accepts or declines responder's invitations based on the top of the range
@@ -239,7 +258,10 @@ consulted.
   without a stopper for notrump raises a minor overcall to 5m with 4+
   support; with only three, a cue bid of their suit shows a limit raise
   or better and the overcaller chooses 3NT with a stopper, signs off at
-  the cheapest level with a minimum, or raises to game with 13+), and
+  the cheapest level with a minimum, or raises to game with 13+);
+  opposite a weak jump overcall (5-9) the constructive advances — new
+  suits, notrump rungs, the game raise, and the cue — all need about a
+  king more, while simple and jump raises stay preemptive; and
   3NT needs only 12 opposite a sound overcall of a preempt; systems on
   over partner's 1NT overcall (direct or balancing), with the overcaller
   answering Stayman and completing transfers like a 1NT opener. Opposite
@@ -328,7 +350,7 @@ dart run scripts/bidding_audit.dart --deals 5000 --chaos 0.15
 DDS_LIB=native/libdds.dylib dart run scripts/bidding_accuracy.dart --deals 1200
 ```
 
-### Audit conventions and current results (2026-08-21)
+### Audit conventions and current results (2026-08-26)
 
 Seed 1 over 3000 deals is the held-out **test set**: fixes are mined from
 other seeds (42 at 4000 deals is the current dev seed) so that seed 1 stays
@@ -337,19 +359,20 @@ down as gaps get fixed; a jump up means a regression.
 
 | Run | Result |
 | --- | --- |
-| seed 1, 3000 deals (test set) | 645 findings, 0 hard failures |
+| seed 1, 3000 deals (test set) | 655 findings, 0 hard failures |
 | seed 42, 4000 deals (dev) | 895 findings, 0 hard failures |
 | chaos 0.15, 5000 deals | 0 hard failures |
 
-Seed 1 findings by category: fallback-used 425, missed-game 142,
-silly-strain 51, missed-slam 25, thin-game 1, no-rule-matched 1. The
-missed-game lint excuses stops below game when an opponent-bid suit is
-unstopped, there is no eight-card major fit, and the side holds under 28
-points (no game is attractive there); missed-slam mostly reflects the
-deliberately minimal slam machinery.
+Seed 1 findings by category: fallback-used 433, missed-game 136,
+silly-strain 51, missed-slam 25, thin-game 1, no-rule-matched 1.
+Fallback-used is monitoring, not failure. The missed-game lint excuses
+stops below game when an opponent-bid suit is unstopped, there is no
+eight-card major fit, and the side holds under 28 points (no game is
+attractive there); missed-slam mostly reflects the deliberately minimal
+slam machinery.
 
-Double-dummy accuracy (1200 deals): games bid make 73.2% of the time
-(precision), and 61.8% of double-dummy-makeable games get bid (recall);
+Double-dummy accuracy (1200 deals): games bid make 73.3% of the time
+(precision), and 62.6% of double-dummy-makeable games get bid (recall);
 slams are 3/4 bid-and-making with 1.9% recall of the 161 DD slam chances —
 most DD "slams" lack the combined strength any bidding system would need
 (only 24 of the 161 have 31+ combined HCP).

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -1908,7 +1908,7 @@ List<SaycRule> _rebidAfter1ntResponseRules(ContractBid opening) {
           description: "Balanced minimum, content to play 1NT",
           hcp: const Range(low: 12, high: 14)),
       ignoreInfo: true,
-      require: (h) => h.isBalanced && h.hcp <= 14,
+      require: (h) => h.isBalanced,
     ),
   ];
   // Jump shifts: 18+, lower-ranking suits only.
@@ -1949,14 +1949,11 @@ List<SaycRule> _rebidAfter1ntResponseRules(ContractBid opening) {
       require: (h) => _secondSuitChoice(h, mySuit, {mySuit}, response) == s,
     ));
   }
-  // Usually 13-16, but off-book hands with no descriptive rebid (e.g. a
-  // balanced 15-17 that opened the suit instead of 1NT) land here too, so
-  // no advertised ceiling.
   rules.add(SaycRule(
     BidAction.pass(),
     BidMeaning(
         description: "Minimum with no better rebid",
-        totalPoints: const Range(low: 13)),
+        totalPoints: const Range(low: 13, high: 16)),
     ignoreInfo: true,
   ));
   return rules;
@@ -2074,20 +2071,14 @@ List<SaycRule> _rebidAfterNewSuitRules(
       ignoreInfo: true,
       require: (h) => h.isBalanced && h.hcp >= 18,
     ),
-    // A balanced 15-17 would normally have opened 1NT, but the position
-    // can arise (a human-style 1M opening on a good suit). Opposite a
-    // forcing two-level response (10+) those values make game: bid it
-    // rather than falling into the 12-14 rebid below.
-    if (response.count >= 2)
-      SaycRule(
-        BidAction.noTrump(3),
-        BidMeaning(
-            description: "15-17 HCP, balanced (usually opened 1NT)",
-            hcp: const Range(low: 15, high: 17),
-            balanced: true),
-        ignoreInfo: true,
-        require: (h) => h.isBalanced && h.hcp >= 15,
-      ),
+    // Matches any balanced hand with no upper bound on purpose: a
+    // balanced 15-17 always opens 1NT, so engine-opened hands can't be
+    // stronger than 14 here. An off-book 15-17 (a human-style 1M opening
+    // on a good suit) is deliberately absorbed rather than given its own
+    // rung: keeping this bid's advertised 12-14 — and the 3NT rebid's
+    // 18-19 — crisp is worth more to hand inference (fallback floors
+    // today, Monte Carlo constraints later) than an accurate rebid on a
+    // hand the engine would never open this way.
     SaycRule(
       BidAction.noTrump(response.count),
       BidMeaning(
@@ -2095,20 +2086,8 @@ List<SaycRule> _rebidAfterNewSuitRules(
           hcp: const Range(low: 12, high: 14),
           balanced: true),
       ignoreInfo: true,
-      require: (h) => h.isBalanced && h.hcp <= 14,
+      require: (h) => h.isBalanced,
     ),
-    // Off-book 15-17 balanced over a one-level response: the cheap
-    // notrump is still the most descriptive call, honestly labeled.
-    if (response.count == 1)
-      SaycRule(
-        BidAction.noTrump(1),
-        BidMeaning(
-            description: "15-17 HCP, balanced (usually opened 1NT)",
-            hcp: const Range(low: 15, high: 17),
-            balanced: true),
-        ignoreInfo: true,
-        require: (h) => h.isBalanced,
-      ),
     SaycRule(
       BidAction.contract(cheapestLevel(mySuit, response), mySuit),
       BidMeaning(
@@ -5582,6 +5561,9 @@ List<SaycRule> negativeDoubleRebidRules(
         require: (h) =>
             h.isBalanced && h.hasStopper(overcallSuit) && h.hcp >= 18,
       ),
+      // Unbounded above like the 12-14 rebid in _rebidAfterNewSuitRules:
+      // stronger balanced hands opened 1NT, and off-book ones are
+      // absorbed to keep the advertised range crisp for inference.
       SaycRule(
         BidAction.withBid(ContractBid(ntLevel, null)),
         BidMeaning(
@@ -5589,20 +5571,7 @@ List<SaycRule> negativeDoubleRebidRules(
             hcp: const Range(low: 12, high: 14),
             balanced: true),
         ignoreInfo: true,
-        require: (h) =>
-            h.isBalanced && h.hcp <= 14 && h.hasStopper(overcallSuit),
-      ),
-      // Off-book 15-17 balanced (usually opened 1NT): still the most
-      // descriptive rebid, honestly labeled.
-      SaycRule(
-        BidAction.withBid(ContractBid(ntLevel, null)),
-        BidMeaning(
-            description: "15-17 balanced with a stopper (usually opened 1NT)",
-            hcp: const Range(low: 15, high: 17),
-            balanced: true),
-        ignoreInfo: true,
-        require: (h) =>
-            h.isBalanced && h.hcp <= 17 && h.hasStopper(overcallSuit),
+        require: (h) => h.isBalanced && h.hasStopper(overcallSuit),
       ),
     ] else
       SaycRule(

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -1026,33 +1026,45 @@ List<SaycRule> preemptResponseRules(ContractBid opening) {
     ));
   }
   if (opening.count == 3 && !_isMajor(suit)) {
-    // With a fit, partner's seven-card suit will run: game values (15+)
-    // are enough for 3NT, and shapely fits too weak for notrump can raise.
+    // Over a minor preempt, 3NT needs the side suits stopped (partner's
+    // seven-card suit supplies the tricks; a fit lowers the bar to 15).
+    // Game values with a fit but an unstopped suit raise to five instead:
+    // that is the classic hand that can't risk notrump.
+    bool sideSuitsStopped(HandAnalysis h) =>
+        Suit.values.where((s) => s != suit).every(h.hasStopper);
     rules.add(SaycRule(
       BidAction.noTrump(3),
       BidMeaning(
-        description: "To play: game values with a fit for partner's suit",
+        description:
+            "To play: game values, a fit, and the side suits stopped",
         hcp: const Range(low: 15),
         suitLengths: {suit: const Range(low: 3)},
       ),
+      require: sideSuitsStopped,
     ));
-  }
-  if (opening.count == 3) {
+    rules.add(SaycRule(
+      BidAction.noTrump(3),
+      BidMeaning(
+        description: "To play: strong hand with the side suits stopped",
+        hcp: const Range(low: 16),
+      ),
+      require: sideSuitsStopped,
+    ));
+    rules.add(SaycRule(
+      BidAction.contract(5, suit),
+      BidMeaning(
+        description: "Raise to game: 3+ ${_suitNames[suit]}, 16+ points, "
+            "not suited to notrump",
+        totalPoints: const Range(low: 16),
+        suitLengths: {suit: const Range(low: 3)},
+      ),
+    ));
+  } else if (opening.count == 3) {
     rules.add(SaycRule(
       BidAction.noTrump(3),
       BidMeaning(
         description: "To play: strong hand over partner's preempt",
         hcp: const Range(low: 16),
-      ),
-    ));
-  }
-  if (opening.count == 3 && !_isMajor(suit)) {
-    rules.add(SaycRule(
-      BidAction.contract(5, suit),
-      BidMeaning(
-        description: "Raise to game: 4+ ${_suitNames[suit]}, 17+ points",
-        totalPoints: const Range(low: 17),
-        suitLengths: {suit: const Range(low: 4)},
       ),
     ));
   }

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -961,14 +961,40 @@ List<SaycRule> weakTwoResponseRules(ContractBid opening) {
       require: (h) => h.count(suit) >= 3,
     ));
   }
-  rules.addAll([
-    SaycRule(
-      BidAction.noTrump(3),
-      BidMeaning(
-        description: "To play: strong hand, no trump fit required",
-        hcp: const Range(low: 16),
-      ),
+  rules.add(SaycRule(
+    BidAction.noTrump(3),
+    BidMeaning(
+      description: "To play: strong hand, no trump fit required",
+      hcp: const Range(low: 16),
     ),
+  ));
+  // RONF: a new suit below game is natural (a good 5+ card suit) and
+  // forcing for one round; opener raises with support, else rebids the
+  // preempt suit.
+  for (final s in Suit.values) {
+    if (s == suit) continue;
+    final level = cheapestLevel(s, opening);
+    if (level > 3) continue;
+    rules.add(SaycRule(
+      BidAction.contract(level, s),
+      BidMeaning(
+        description:
+            "New suit (forcing): good 5+ ${_suitNames[s]}, 15+ points",
+        totalPoints: const Range(low: 15),
+        suitLengths: {s: const Range(low: 5)},
+      ),
+      require: (h) =>
+          h.topHonorCount(s) >= 2 &&
+          bestSuit(
+                  h,
+                  Suit.values.where((x) =>
+                      x != suit &&
+                      h.count(x) >= 5 &&
+                      h.topHonorCount(x) >= 2)) ==
+              s,
+    ));
+  }
+  rules.addAll([
     SaycRule(
       BidAction.contract(3, suit),
       BidMeaning(
@@ -999,12 +1025,34 @@ List<SaycRule> preemptResponseRules(ContractBid opening) {
       ),
     ));
   }
+  if (opening.count == 3 && !_isMajor(suit)) {
+    // With a fit, partner's seven-card suit will run: game values (15+)
+    // are enough for 3NT, and shapely fits too weak for notrump can raise.
+    rules.add(SaycRule(
+      BidAction.noTrump(3),
+      BidMeaning(
+        description: "To play: game values with a fit for partner's suit",
+        hcp: const Range(low: 15),
+        suitLengths: {suit: const Range(low: 3)},
+      ),
+    ));
+  }
   if (opening.count == 3) {
     rules.add(SaycRule(
       BidAction.noTrump(3),
       BidMeaning(
         description: "To play: strong hand over partner's preempt",
         hcp: const Range(low: 16),
+      ),
+    ));
+  }
+  if (opening.count == 3 && !_isMajor(suit)) {
+    rules.add(SaycRule(
+      BidAction.contract(5, suit),
+      BidMeaning(
+        description: "Raise to game: 4+ ${_suitNames[suit]}, 17+ points",
+        totalPoints: const Range(low: 17),
+        suitLengths: {suit: const Range(low: 4)},
       ),
     ));
   }
@@ -1072,8 +1120,15 @@ List<SaycRule>? blackwoodPlacementRules(
   if (trump == null) return null;
   final trumpSuit = trump;
 
-  int partnerAces(HandAnalysis h) =>
-      shown ?? (h.aces >= 1 ? 0 : 4);
+  // The 5C answer is ambiguous (0 or 4). An asker with an ace resolves it
+  // to 0 (only four exist). An ace-less asker reads it as 4: for both
+  // hands to be ace-less, the partnership would need essentially all 24
+  // non-ace HCP plus freak shape to reach a Blackwood auction, leaving
+  // the silent opponents holding the four aces and a huge fit — not a
+  // realistic deal. A human partner answering 5C is far more likely to
+  // have shaded a strength cap while holding four aces (AAAA-and-nothing
+  // hands are classically undervalued) than to hold the ace-less freak.
+  int partnerAces(HandAnalysis h) => shown ?? (h.aces >= 1 ? 0 : 4);
 
   final rules = <SaycRule>[
     SaycRule(
@@ -1082,7 +1137,14 @@ List<SaycRule>? blackwoodPlacementRules(
       require: (h) => h.aces + partnerAces(h) >= 3,
     ),
   ];
-  if (_strainOrder(trumpSuit) > _strainOrder(answerSuit)) {
+  if (trumpSuit == answerSuit) {
+    // The answer landed in the trump suit: five of trumps is the current
+    // contract, so the signoff is a pass.
+    rules.add(SaycRule(
+      BidAction.pass(),
+      BidMeaning(description: "Signing off: two aces missing"),
+    ));
+  } else if (_strainOrder(trumpSuit) > _strainOrder(answerSuit)) {
     rules.add(SaycRule(
       BidAction.contract(5, trumpSuit),
       BidMeaning(description: "Signing off: two aces missing"),
@@ -1134,6 +1196,10 @@ List<SaycRule>? gerberContinuationRules(BidAction answer) {
     _ => null,
   };
 
+  // Unlike Blackwood, assuming 4 on the ambiguous answer is provably safe
+  // here: Gerber's HCP floors (18+ over 1NT, 13+ over 2NT) leave too few
+  // non-ace HCP outstanding for the notrump opener to hold its range
+  // without 3-4 aces, and with 3 it would have answered differently.
   int partnerAces(HandAnalysis h) => shown ?? (h.aces >= 1 ? 0 : 4);
 
   final rules = <SaycRule>[
@@ -1234,6 +1300,30 @@ List<SaycRule>? openerRebidRules(BidAction opening, BidAction response,
           BidAction.pass(),
           BidMeaning(description: "Preemptive opener has nothing more to say"),
         )
+      ];
+    }
+    final resp = response.contractBid!;
+    if (openBid.count == 2 &&
+        resp.trump != null &&
+        resp.count <= 3 &&
+        resp.count < (_isMajor(resp.trump!) ? 4 : 5)) {
+      // Partner's new suit over the weak two is forcing (RONF): raise with
+      // support, otherwise rebid the preempt suit.
+      final pSuit = resp.trump!;
+      return [
+        SaycRule(
+          BidAction.contract(cheapestLevel(pSuit, resp), pSuit),
+          BidMeaning(
+            description: "Raising partner's forcing new suit",
+            suitLengths: {pSuit: const Range(low: 3)},
+          ),
+        ),
+        SaycRule(
+          BidAction.contract(cheapestLevel(openBid.trump!, resp), openBid.trump!),
+          BidMeaning(
+              description: "No fit for partner's suit: rebidding the preempt"),
+          ignoreInfo: true,
+        ),
       ];
     }
     return null;
@@ -1657,6 +1747,23 @@ List<SaycRule> _oneSuitRebidRules(ContractBid opening, ContractBid response,
     return _rebidAfter1ntResponseRules(opening);
   }
   if (response.trump == null) {
+    if (!contested && response.count == 3 && !_isMajor(mySuit)) {
+      // The 3NT response to a minor showed 16+ balanced: 17 of our own
+      // makes 33+ combined a certainty.
+      return [
+        SaycRule(
+          BidAction.noTrump(6),
+          BidMeaning(
+              description: "Slam: 33+ combined HCP opposite the 16+ response",
+              hcp: const Range(low: 17)),
+        ),
+        SaycRule(
+          BidAction.pass(),
+          BidMeaning(description: "Respecting partner's signoff"),
+          ignoreInfo: true,
+        ),
+      ];
+    }
     return [
       SaycRule(BidAction.pass(),
           BidMeaning(description: "Respecting partner's signoff"))
@@ -1860,30 +1967,39 @@ List<SaycRule> _rebidAfterNewSuitRules(
   final pName = _suitNames[partnerSuit]!;
   final partnerMajor = _isMajor(partnerSuit);
 
+  // A two-level heart response to 1S promised five hearts, so three-card
+  // support completes an eight-card fit; every other new suit shows only
+  // four and needs four-card support to raise.
+  final minSupport = (mySuit == Suit.spades &&
+          partnerSuit == Suit.hearts &&
+          response.count == 2)
+      ? 3
+      : 4;
+
   List<SaycRule> raiseRules() {
     final out = <SaycRule>[
       SaycRule(
         BidAction.contract(response.count + 1, partnerSuit),
         BidMeaning(
-          description: "Raise: 4+ $pName, minimum opening",
+          description: "Raise: $minSupport+ $pName, minimum opening",
           totalPoints: const Range(low: 13, high: 15),
-          suitLengths: {partnerSuit: const Range(low: 4)},
+          suitLengths: {partnerSuit: Range(low: minSupport)},
         ),
         ignoreInfo: true,
         require: (h) =>
-            h.count(partnerSuit) >= 4 && h.totalPoints <= 15,
+            h.count(partnerSuit) >= minSupport && h.totalPoints <= 15,
       ),
       SaycRule(
         BidAction.contract(response.count + 2, partnerSuit),
         BidMeaning(
-          description: "Jump raise: 4+ $pName, extra values",
+          description: "Jump raise: $minSupport+ $pName, extra values",
           totalPoints:
               partnerMajor ? const Range(low: 16, high: 18) : const Range(low: 16),
-          suitLengths: {partnerSuit: const Range(low: 4)},
+          suitLengths: {partnerSuit: Range(low: minSupport)},
         ),
         ignoreInfo: true,
         require: (h) =>
-            h.count(partnerSuit) >= 4 &&
+            h.count(partnerSuit) >= minSupport &&
             (h.totalPoints <= 18 || !partnerMajor),
       ),
     ];
@@ -1891,12 +2007,12 @@ List<SaycRule> _rebidAfterNewSuitRules(
       out.add(SaycRule(
         BidAction.contract(4, partnerSuit),
         BidMeaning(
-          description: "Raise to game: 4+ $pName, maximum opening",
-          totalPoints: const Range(low: 19, high: 21),
-          suitLengths: {partnerSuit: const Range(low: 4)},
+          description: "Raise to game: $minSupport+ $pName, maximum opening",
+          totalPoints: const Range(low: 19),
+          suitLengths: {partnerSuit: Range(low: minSupport)},
         ),
         ignoreInfo: true,
-        require: (h) => h.count(partnerSuit) >= 4,
+        require: (h) => h.count(partnerSuit) >= minSupport,
       ));
     }
     return out;
@@ -1920,6 +2036,27 @@ List<SaycRule> _rebidAfterNewSuitRules(
           require: (h) => h.count(major) >= 4,
         ));
       }
+    }
+    if (response.count == 2) {
+      // The jump raise of a two-over-one minor lands at the four level,
+      // past 3NT — with game values, a fit, and the unbid suits stopped,
+      // nine tricks in notrump beat eleven in the minor.
+      rules.add(SaycRule(
+        BidAction.noTrump(3),
+        BidMeaning(
+          description: "Game values with a $pName fit, unbid suits stopped",
+          totalPoints: const Range(low: 16, high: 18),
+          suitLengths: {partnerSuit: const Range(low: 4)},
+        ),
+        ignoreInfo: true,
+        require: (h) =>
+            h.count(partnerSuit) >= 4 &&
+            h.totalPoints >= 16 &&
+            h.totalPoints <= 18 &&
+            Suit.values
+                .where((s) => s != mySuit && s != partnerSuit)
+                .every(h.hasStopper),
+      ));
     }
     rules.addAll(raiseRules());
   }
@@ -2140,21 +2277,24 @@ List<SaycRule>? responderRebidRules(
       final major = transferTargets[response]!;
       final name = _suitNames[major]!;
       return [
+        // The suit rung counts total points: with six trumps opposite a
+        // 2NT opening the fit is known, so length points count toward game.
+        SaycRule(
+          BidAction.contract(4, major),
+          BidMeaning(
+            description: "To play: 6+ $name, game values",
+            totalPoints: const Range(low: 5),
+            suitLengths: {major: const Range(low: 6)},
+          ),
+          ignoreInfo: true,
+          require: (h) =>
+              h.count(major) >= 6 && h.totalPoints >= 5 && h.hcp <= 10,
+        ),
         SaycRule(
           BidAction.pass(),
           BidMeaning(
               description: "Signing off after the transfer",
               hcp: const Range(high: 4)),
-        ),
-        SaycRule(
-          BidAction.contract(4, major),
-          BidMeaning(
-            description: "To play: 6+ $name, game values",
-            hcp: const Range(low: 5, high: 10),
-            suitLengths: {major: const Range(low: 6)},
-          ),
-          ignoreInfo: true,
-          require: (h) => h.count(major) >= 6 && h.hcp <= 10,
         ),
         SaycRule(
           BidAction.noTrump(6),
@@ -2199,6 +2339,76 @@ List<SaycRule>? responderRebidRules(
     return _responderRebidAfterSuitRules(
         opening.contractBid!, response, rebid.contractBid!,
         contested: contested);
+  }
+  if (opening.bidType == BidType.contract &&
+      opening.contractBid!.trump != null &&
+      opening.contractBid!.count == 2 &&
+      opening.contractBid!.trump != Suit.clubs) {
+    return _responderRebidAfterWeakTwoRules(
+        opening.contractBid!, response, rebid.contractBid!);
+  }
+  return null;
+}
+
+/// Responder's continuation after a forcing new suit (RONF) over partner's
+/// weak two: opener has raised with support or rebid the preempt suit.
+List<SaycRule>? _responderRebidAfterWeakTwoRules(
+    ContractBid opening, BidAction response, ContractBid rebid) {
+  final oSuit = opening.trump!;
+  final respBid =
+      response.bidType == BidType.contract ? response.contractBid : null;
+  if (respBid == null || respBid.trump == null || respBid.trump == oSuit) {
+    return null;
+  }
+  final mySuit = respBid.trump!;
+  final myGameLevel = _isMajor(mySuit) ? 4 : 5;
+  if (rebid.trump == mySuit) {
+    // Opener raised the forcing suit: the eight-card fit is found.
+    if (rebid.count >= myGameLevel) {
+      return [
+        SaycRule(BidAction.pass(),
+            BidMeaning(description: "Game reached opposite the raise"))
+      ];
+    }
+    return [
+      SaycRule(
+        BidAction.contract(myGameLevel, mySuit),
+        BidMeaning(
+            description: "Bidding game opposite the raise",
+            totalPoints: const Range(low: 17)),
+        ignoreInfo: true,
+        require: (h) => h.totalPoints >= 17,
+      ),
+      SaycRule(
+        BidAction.pass(),
+        BidMeaning(
+            description: "Minimum for the forcing bid; stopping here",
+            totalPoints: const Range(low: 15, high: 16)),
+        ignoreInfo: true,
+      ),
+    ];
+  }
+  if (rebid.trump == oSuit) {
+    // No fit: play in our own long suit if we have one, else in the
+    // preempt suit.
+    final level = cheapestLevel(mySuit, rebid);
+    return [
+      if (level <= myGameLevel)
+        SaycRule(
+          BidAction.contract(level, mySuit),
+          BidMeaning(
+            description: "Rebidding a self-sufficient 6+ card suit",
+            suitLengths: {mySuit: const Range(low: 6)},
+          ),
+          ignoreInfo: true,
+          require: (h) => h.count(mySuit) >= 6,
+        ),
+      SaycRule(
+        BidAction.pass(),
+        BidMeaning(description: "No fit; settling for the preempt suit"),
+        ignoreInfo: true,
+      ),
+    ];
   }
   return null;
 }
@@ -2290,20 +2500,38 @@ List<SaycRule>? _responderRebidAfter1ntRules(
   if (transferTargets.containsKey(response)) {
     final major = transferTargets[response]!;
     final name = _suitNames[major]!;
+    // With six or more trumps the fit is known, so length points count:
+    // the suit rungs below use total points where the notrump rungs stay
+    // in HCP. They sit ahead of the signoff so a shapely 7-HCP hand still
+    // invites or bids game.
     return [
+      SaycRule(
+        BidAction.contract(3, major),
+        BidMeaning(
+          description:
+              "Inviting game: 6+ $name, ${8 + s}-${9 + s} total points",
+          totalPoints: Range(low: 8 + s, high: 9 + s),
+          suitLengths: {major: const Range(low: 6)},
+        ),
+      ),
+      SaycRule(
+        BidAction.contract(4, major),
+        BidMeaning(
+          description: "To play: 6+ $name, game values",
+          totalPoints: Range(low: 10 + s),
+          suitLengths: {major: const Range(low: 6)},
+        ),
+        ignoreInfo: true,
+        require: (h) =>
+            h.count(major) >= 6 &&
+            h.totalPoints >= 10 + s &&
+            h.hcp <= 15 + s,
+      ),
       SaycRule(
         BidAction.pass(),
         BidMeaning(
             description: "Signing off after the transfer",
             hcp: Range(high: 7 + s)),
-      ),
-      SaycRule(
-        BidAction.contract(3, major),
-        BidMeaning(
-          description: "Inviting game: 6+ $name, ${8 + s}-${9 + s} HCP",
-          hcp: Range(low: 8 + s, high: 9 + s),
-          suitLengths: {major: const Range(low: 6)},
-        ),
       ),
       SaycRule(
         BidAction.noTrump(2),
@@ -2312,16 +2540,6 @@ List<SaycRule>? _responderRebidAfter1ntRules(
           hcp: Range(low: 8 + s, high: 9 + s),
           suitLengths: {major: const Range(low: 5, high: 5)},
         ),
-      ),
-      SaycRule(
-        BidAction.contract(4, major),
-        BidMeaning(
-          description: "To play: 6+ $name, game values",
-          hcp: Range(low: 10 + s, high: 15 + s),
-          suitLengths: {major: const Range(low: 6)},
-        ),
-        ignoreInfo: true,
-        require: (h) => h.count(major) >= 6 && h.hcp <= 15 + s,
       ),
       SaycRule(
         BidAction.noTrump(6),
@@ -2488,6 +2706,12 @@ List<SaycRule>? _rebidAfter2cPositiveRules(
     }
     if (rebidBid.trump != null) {
       return [
+        SaycRule(
+          BidAction.noTrump(6),
+          BidMeaning(
+              description: "Slam: 33+ combined points opposite the 2C opener",
+              hcp: const Range(low: 11)),
+        ),
         if (_isMajor(rebidBid.trump!))
           SaycRule(
             BidAction.contract(4, rebidBid.trump!),
@@ -2553,6 +2777,12 @@ List<SaycRule>? _rebidAfter2cPositiveRules(
   }
   // Opener showed a suit of his own.
   return [
+    SaycRule(
+      BidAction.noTrump(6),
+      BidMeaning(
+          description: "Slam: 33+ combined points opposite the 2C opener",
+          hcp: const Range(low: 11)),
+    ),
     if (_isMajor(rebidBid.trump!))
       SaycRule(
         BidAction.contract(4, rebidBid.trump!),
@@ -2895,12 +3125,14 @@ List<SaycRule> _responderRebidAfterSuitRules(
       // Jump raise, 16-18.
       if (!gameIsLegal) {
         if (!myMajor && rebid.count == 4) {
+          // A two-over-one already promised 10+, so eleven tricks need
+          // real extras; with less, four of the minor is the spot.
           return [
             SaycRule(
               BidAction.contract(5, mySuit),
               BidMeaning(
                   description: "Accepting the invitation",
-                  totalPoints: const Range(low: 10)),
+                  totalPoints: const Range(low: 12)),
             ),
             SaycRule(
                 BidAction.pass(),
@@ -3356,6 +3588,29 @@ List<SaycRule>? openerThirdCallRules(
             description: "Choosing game; the 2C auction is game-forcing"),
       ));
       return rules;
+    }
+    final respBid2c =
+        response.bidType == BidType.contract ? response.contractBid : null;
+    final positiveResponse = response == BidAction.noTrump(2) ||
+        (respBid2c != null &&
+            respBid2c.trump != null &&
+            _is2cPositiveSuitResponse(respBid2c));
+    if (positiveResponse && r2 == BidAction.noTrump(3)) {
+      // Responder's positive showed 8+ HCP; with 25+ of our own, 33+
+      // combined is certain even opposite the minimum.
+      return [
+        SaycRule(
+          BidAction.noTrump(6),
+          BidMeaning(
+              description: "Slam: 33+ combined points opposite the positive",
+              hcp: const Range(low: 25)),
+        ),
+        SaycRule(
+          BidAction.pass(),
+          BidMeaning(description: "Responder has placed the contract"),
+          ignoreInfo: true,
+        ),
+      ];
     }
     return [
       SaycRule(BidAction.pass(),
@@ -4653,6 +4908,9 @@ List<SaycRule> overcallerNewSuitRebidRules(
         h.totalPoints >= (_isMajor(aSuit) ? 14 : 15) &&
         h.count(aSuit) >= (_isMajor(aSuit) ? 3 : 4),
   );
+  // The advance showed only 10+: game in notrump needs 14 from the
+  // overcaller — or 13 when the overcalled suit is a running 6+ carder
+  // whose tricks make up for the missing point.
   final nt3 = SaycRule(
     BidAction.noTrump(3),
     BidMeaning(
@@ -4661,7 +4919,10 @@ List<SaycRule> overcallerNewSuitRebidRules(
         totalPoints: const Range(low: 13)),
     ignoreInfo: true,
     require: (h) =>
-        h.totalPoints >= 13 &&
+        (h.totalPoints >= 14 ||
+            (h.totalPoints >= 13 &&
+                h.count(mySuit) >= 6 &&
+                h.topHonorCount(mySuit) >= 2)) &&
         h.hasStopper(theirSuit) &&
         cheapestLevel(null, advance) <= 3,
   );
@@ -4784,6 +5045,12 @@ List<SaycRule>? advanceOvercallRules(
   final name = _suitNames[suit]!;
   final theirSuit = theirOpening.trump;
   final raiseLevel = cheapestLevel(suit, over);
+  // A weak jump overcall showed only 5-9 HCP: constructive advances need
+  // about a king more than opposite a sound overcall (raises stay
+  // preemptive and keep their normal ranges).
+  final weakJump = theirOpening.count == 1 &&
+      overcall.count > cheapestLevel(suit, theirOpening);
+  final shift = weakJump ? 4 : 0;
 
   bool stopperOk(HandAnalysis h) =>
       theirSuit == null || h.hasStopper(theirSuit);
@@ -4820,7 +5087,7 @@ List<SaycRule>? advanceOvercallRules(
       BidAction.contract(4, suit),
       BidMeaning(
         description: "Raise to game: 3+ $name",
-        totalPoints: const Range(low: 13),
+        totalPoints: Range(low: 13 + shift),
         suitLengths: {suit: const Range(low: 3)},
       ),
     ));
@@ -4842,8 +5109,8 @@ List<SaycRule>? advanceOvercallRules(
     rules.add(SaycRule(
       BidAction.contract(level, s),
       BidMeaning(
-        description: "New suit: 5+ ${_suitNames[s]}, 10+ points",
-        totalPoints: const Range(low: 10),
+        description: "New suit: 5+ ${_suitNames[s]}, ${10 + shift}+ points",
+        totalPoints: Range(low: 10 + shift),
         suitLengths: {s: const Range(low: 5)},
       ),
       // With game values and support for the overcall, the forcing
@@ -4851,7 +5118,7 @@ List<SaycRule>? advanceOvercallRules(
       // change of suit, which the overcaller may pass.
       require: (h) =>
           newSuitChoice(h) == s &&
-          (h.totalPoints <= 12 || h.count(suit) < 3),
+          (h.totalPoints <= 12 + shift || h.count(suit) < 3),
     ));
   }
   final ntLevel = cheapestLevel(null, over);
@@ -4869,7 +5136,7 @@ List<SaycRule>? advanceOvercallRules(
       BidAction.noTrump(2),
       BidMeaning(
           description: "Inviting game with $stopPhrase",
-          totalPoints: const Range(low: 12, high: 13)),
+          totalPoints: Range(low: 12 + shift, high: 13 + shift)),
       require: stopperOk,
     ));
   }
@@ -4881,7 +5148,7 @@ List<SaycRule>? advanceOvercallRules(
       BidAction.noTrump(3),
       BidMeaning(
           description: "Game values with $stopPhrase",
-          totalPoints: Range(low: strongOvercall ? 12 : 14)),
+          totalPoints: Range(low: (strongOvercall ? 12 : 14) + shift)),
       require: stopperOk,
     ));
   }
@@ -4890,8 +5157,8 @@ List<SaycRule>? advanceOvercallRules(
     rules.add(SaycRule(
       BidAction.contract(5, suit),
       BidMeaning(
-        description: "Raise to game: 4+ $name, 13+ points",
-        totalPoints: const Range(low: 13),
+        description: "Raise to game: 4+ $name, ${13 + shift}+ points",
+        totalPoints: Range(low: 13 + shift),
         suitLengths: {suit: const Range(low: 4)},
       ),
     ));
@@ -4903,7 +5170,7 @@ List<SaycRule>? advanceOvercallRules(
         BidAction.contract(cueLevel, theirSuit),
         BidMeaning(
           description: "Cue bid: raise of $name, game values",
-          totalPoints: const Range(low: 13),
+          totalPoints: Range(low: 13 + shift),
           suitLengths: {suit: const Range(low: 3)},
           artificial: true,
         ),
@@ -4914,7 +5181,7 @@ List<SaycRule>? advanceOvercallRules(
         BidAction.contract(raiseLevel + 1, suit),
         BidMeaning(
           description: "Jump raise: 3 $name, game values, no stopper",
-          totalPoints: const Range(low: 13),
+          totalPoints: Range(low: 13 + shift),
           suitLengths: {suit: const Range(low: 3)},
         ),
       ));
@@ -5787,14 +6054,19 @@ List<SaycRule> actionDoubleAdvanceRules(
   final oSuit = opening.trump!;
   final rSuit = response.trump;
   return [
+    // The action double showed only 11+ with no clear bid, so converting
+    // needs real trump tricks: four trumps, or three with honors sitting
+    // over declarer. A doubleton pulls to the cheapest fit below.
     SaycRule(
       BidAction.pass(),
       BidMeaning(
           description:
-              "Converting the double to penalties with trump length",
-          suitLengths: {theirSuit: const Range(low: 2)}),
+              "Converting the double to penalties with trump tricks",
+          suitLengths: {theirSuit: const Range(low: 3)}),
       ignoreInfo: true,
-      require: (h) => h.count(theirSuit) >= 2,
+      require: (h) =>
+          h.count(theirSuit) >= 4 ||
+          (h.count(theirSuit) == 3 && h.suitHcp(theirSuit) >= 4),
     ),
     if (rSuit != null &&
         rSuit != theirSuit &&

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -1908,7 +1908,7 @@ List<SaycRule> _rebidAfter1ntResponseRules(ContractBid opening) {
           description: "Balanced minimum, content to play 1NT",
           hcp: const Range(low: 12, high: 14)),
       ignoreInfo: true,
-      require: (h) => h.isBalanced,
+      require: (h) => h.isBalanced && h.hcp <= 14,
     ),
   ];
   // Jump shifts: 18+, lower-ranking suits only.
@@ -1949,11 +1949,14 @@ List<SaycRule> _rebidAfter1ntResponseRules(ContractBid opening) {
       require: (h) => _secondSuitChoice(h, mySuit, {mySuit}, response) == s,
     ));
   }
+  // Usually 13-16, but off-book hands with no descriptive rebid (e.g. a
+  // balanced 15-17 that opened the suit instead of 1NT) land here too, so
+  // no advertised ceiling.
   rules.add(SaycRule(
     BidAction.pass(),
     BidMeaning(
         description: "Minimum with no better rebid",
-        totalPoints: const Range(low: 13, high: 16)),
+        totalPoints: const Range(low: 13)),
     ignoreInfo: true,
   ));
   return rules;
@@ -2071,6 +2074,20 @@ List<SaycRule> _rebidAfterNewSuitRules(
       ignoreInfo: true,
       require: (h) => h.isBalanced && h.hcp >= 18,
     ),
+    // A balanced 15-17 would normally have opened 1NT, but the position
+    // can arise (a human-style 1M opening on a good suit). Opposite a
+    // forcing two-level response (10+) those values make game: bid it
+    // rather than falling into the 12-14 rebid below.
+    if (response.count >= 2)
+      SaycRule(
+        BidAction.noTrump(3),
+        BidMeaning(
+            description: "15-17 HCP, balanced (usually opened 1NT)",
+            hcp: const Range(low: 15, high: 17),
+            balanced: true),
+        ignoreInfo: true,
+        require: (h) => h.isBalanced && h.hcp >= 15,
+      ),
     SaycRule(
       BidAction.noTrump(response.count),
       BidMeaning(
@@ -2078,8 +2095,20 @@ List<SaycRule> _rebidAfterNewSuitRules(
           hcp: const Range(low: 12, high: 14),
           balanced: true),
       ignoreInfo: true,
-      require: (h) => h.isBalanced,
+      require: (h) => h.isBalanced && h.hcp <= 14,
     ),
+    // Off-book 15-17 balanced over a one-level response: the cheap
+    // notrump is still the most descriptive call, honestly labeled.
+    if (response.count == 1)
+      SaycRule(
+        BidAction.noTrump(1),
+        BidMeaning(
+            description: "15-17 HCP, balanced (usually opened 1NT)",
+            hcp: const Range(low: 15, high: 17),
+            balanced: true),
+        ignoreInfo: true,
+        require: (h) => h.isBalanced,
+      ),
     SaycRule(
       BidAction.contract(cheapestLevel(mySuit, response), mySuit),
       BidMeaning(
@@ -5560,7 +5589,20 @@ List<SaycRule> negativeDoubleRebidRules(
             hcp: const Range(low: 12, high: 14),
             balanced: true),
         ignoreInfo: true,
-        require: (h) => h.isBalanced && h.hasStopper(overcallSuit),
+        require: (h) =>
+            h.isBalanced && h.hcp <= 14 && h.hasStopper(overcallSuit),
+      ),
+      // Off-book 15-17 balanced (usually opened 1NT): still the most
+      // descriptive rebid, honestly labeled.
+      SaycRule(
+        BidAction.withBid(ContractBid(ntLevel, null)),
+        BidMeaning(
+            description: "15-17 balanced with a stopper (usually opened 1NT)",
+            hcp: const Range(low: 15, high: 17),
+            balanced: true),
+        ignoreInfo: true,
+        require: (h) =>
+            h.isBalanced && h.hcp <= 17 && h.hasStopper(overcallSuit),
       ),
     ] else
       SaycRule(

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -883,19 +883,6 @@ void main() {
           "4C"); // diamonds unstopped: the raise stands
     });
 
-    test("off-book balanced 15-17 bids game over a two-level response", () {
-      // A balanced 15-17 would normally have opened 1NT; if it opened the
-      // suit instead, the forcing 10+ response makes game values, and the
-      // 2NT rebid must not claim 12-14.
-      final result = selectSaycBid(hand("KQJ32", "A32", "K3", "QJ3"),
-          ["1S", "pass", "2C", "pass"].map(BidAction.fromString).toList());
-      expect(result.action.toString(), "3NT"); // 16 HCP, only 3 clubs
-      expect(result.meaning.hcp, const Range(low: 15, high: 17));
-      expect(openingBid("KQ432", "A32", "K3", "J53",
-              history: ["1S", "pass", "2C", "pass"]),
-          "2NT"); // 13: the genuine 12-14 rebid
-    });
-
     test("opener raises the 16+ 3NT response to slam with 17", () {
       expect(openingBid("Q65", "AK8", "AKJ", "A754",
               history: ["1C", "pass", "3NT", "pass"]),

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -635,6 +635,32 @@ void main() {
       expect(openingBid("K32", "Q32", "Q432", "432", history: ["2NT", "pass"]),
           "3NT");
     });
+
+    test("new suit over a weak two is natural and forcing (RONF)", () {
+      expect(openingBid("T", "6", "AKQ8743", "AQ63", history: ["2S", "pass"]),
+          "3D");
+      // Opener raises with support, else rebids the preempt suit.
+      expect(
+          openingBid("KQT982", "65", "J43", "84",
+              history: ["2S", "pass", "3D", "pass"]),
+          "4D");
+      expect(
+          openingBid("KQT982", "65", "J4", "843",
+              history: ["2S", "pass", "3D", "pass"]),
+          "3S");
+      // With no fit responder retreats to the self-sufficient suit.
+      expect(
+          openingBid("T", "6", "AKQ8743", "AQ63",
+              history: ["2S", "pass", "3D", "pass", "3S", "pass"]),
+          "4D");
+    });
+
+    test("minor preempts can be raised and 3NT needs only 15 with a fit", () {
+      expect(openingBid("A64", "K6", "JT965", "AKT", history: ["3C", "pass"]),
+          "3NT"); // 15 HCP with a fit: partner's suit will run
+      expect(openingBid("A4", "KJ42", "-", "AQT9832", history: ["3C", "pass"]),
+          "5C"); // 17 total, huge fit, too few HCP for notrump
+    });
   });
 
   group("opener rebids", () {
@@ -838,6 +864,33 @@ void main() {
       expect(
           openingBid("AKQJ32", "AKQ", "A32", "2", history: after2d), "2S");
     });
+
+    test("opener raises a five-card two-over-one heart response with three", () {
+      expect(openingBid("AKQJ76", "432", "K", "AK5",
+              history: ["1S", "pass", "2H", "pass"]),
+          "4H"); // not a unilateral 4S opposite a possible void
+      expect(openingBid("AKJ32", "432", "K2", "Q32",
+              history: ["1S", "pass", "2H", "pass"]),
+          "3H"); // minimum three-card raise
+    });
+
+    test("minor two-over-one with game values prefers 3NT to the jump raise", () {
+      expect(openingBid("KQJ32", "A2", "K3", "QJ32",
+              history: ["1S", "pass", "2C", "pass"]),
+          "3NT"); // 16-18 with stoppers: nine tricks beat eleven
+      expect(openingBid("AKJ32", "A2", "32", "AQ32",
+              history: ["1S", "pass", "2C", "pass"]),
+          "4C"); // diamonds unstopped: the raise stands
+    });
+
+    test("opener raises the 16+ 3NT response to slam with 17", () {
+      expect(openingBid("Q65", "AK8", "AKJ", "A754",
+              history: ["1C", "pass", "3NT", "pass"]),
+          "6NT"); // 21 opposite 16+: 33+ combined is certain
+      expect(openingBid("J65", "K98", "AKJ", "A754",
+              history: ["1C", "pass", "3NT", "pass"]),
+          "Pass"); // 16 HCP: below the proven-slam line
+    });
   });
 
   group("responder rebids", () {
@@ -854,7 +907,12 @@ void main() {
       final t = ["1NT", "pass", "2D", "pass", "2H", "pass"];
       expect(openingBid("32", "KQ432", "432", "432", history: t), "Pass");
       expect(openingBid("32", "KQ432", "K32", "J32", history: t), "2NT");
-      expect(openingBid("32", "KQJ432", "Q32", "32", history: t), "3H");
+      // With six trumps the fit is known and length points count: 7 HCP
+      // and a sixth heart invite, 8 HCP and a sixth heart bid game.
+      expect(openingBid("32", "KQT432", "Q32", "32", history: t), "3H");
+      expect(openingBid("32", "KQJ432", "Q32", "32", history: t), "4H");
+      expect(openingBid("Q6", "Q987643", "65", "K5", history: t),
+          "4H"); // 7 HCP but 10 total with seven trumps
       expect(openingBid("K2", "KQ432", "K32", "Q32", history: t), "3NT");
       expect(openingBid("32", "KQJ432", "K32", "K2", history: t), "4H");
     });
@@ -903,6 +961,15 @@ void main() {
       expect(openingBid("K32", "432", "32", "KQJ43", history: raised), "Pass");
       final nt = ["1S", "pass", "2C", "pass", "2NT", "pass"];
       expect(openingBid("K32", "A32", "K2", "KQ432", history: nt), "3NT");
+    });
+
+    test("responder needs extras to convert the 4m raise to five", () {
+      expect(openingBid("Q4", "K53", "Q54", "KQJ54",
+              history: ["1S", "pass", "2C", "pass", "4C", "pass"]),
+          "5C"); // 14 total
+      expect(openingBid("43", "K53", "654", "KQJ54",
+              history: ["1S", "pass", "2C", "pass", "4C", "pass"]),
+          "Pass"); // bare minimum stops in 4C
     });
 
     test("2C auction continuations", () {
@@ -998,6 +1065,41 @@ void main() {
           "5S"); // zero aces + one shown
     });
 
+    test("Blackwood signs off with a pass when the answer is the trump suit", () {
+      // 5H shows two aces; the asker has none, so two are missing and the
+      // five-level spot is the current contract.
+      expect(
+          openingBid("KQ", "KQJ5", "KQJ2", "KQJ", history: [
+            "1H", "pass", "2NT", "pass", "3H", "pass", "4NT", "pass",
+            "5H", "pass"
+          ]),
+          "Pass");
+    });
+
+    test("ambiguous Blackwood answer is read as four for an ace-less asker", () {
+      // Both hands ace-less would need the partnership to hold essentially
+      // all 24 non-ace HCP with freak shape while the opponents sat
+      // silently on four aces and a huge fit; a partner answering 5C far
+      // more plausibly shaded a strength cap while holding all four.
+      expect(
+          openingBid("KQ", "KQJ5", "KQJ2", "KQJ", history: [
+            "1H", "pass", "2NT", "pass", "3H", "pass", "4NT", "pass",
+            "5C", "pass"
+          ]),
+          "6H");
+      expect(
+          openingBid("KQ", "KQJ5", "KQJ2", "KQJ", history: [
+            "1H", "pass", "2NT", "pass", "4H", "pass", "4NT", "pass",
+            "5C", "pass"
+          ]),
+          "6H");
+      expect(
+          openingBid("KQ", "KQJ52", "KQJ2", "KJ", history: [
+            "1H", "pass", "3S", "pass", "4NT", "pass", "5C", "pass"
+          ]),
+          "6H");
+    });
+
     test("2C rebid with 28-30 balanced is 4NT, raised to slam with 5+", () {
       expect(
           openingBid("AKQ2", "AKQ", "AK2", "K32",
@@ -1031,6 +1133,20 @@ void main() {
           openingBid("KQ2", "KQ2", "KQ32", "QJ2",
               history: ["1NT", "pass", "4C", "pass", "4H", "pass"]),
           "4NT"); // 0 + 1 aces
+    });
+
+    test("2C auctions reach slam on proven combined strength", () {
+      // Responder's positive showed 8+; with 11+ opposite 22+ that's 33+.
+      expect(
+          openingBid("Q4", "J743", "AQT5", "Q84",
+              history: ["2C", "pass", "2NT", "pass", "3S", "pass"]),
+          "6NT");
+      // Opener with 25+ raises the 3NT retreat opposite the positive.
+      expect(
+          openingBid("AKT65", "AKQ5", "K", "AKJ",
+              history: ["2C", "pass", "2NT", "pass", "3S", "pass",
+                        "3NT", "pass"]),
+          "6NT");
     });
   });
 
@@ -1526,6 +1642,15 @@ void main() {
       expect(openingBid("Q432", "432", "J432", "32", history: ["1H", "X", "2H"]),
           "Pass");
     });
+
+    test("advances of a weak jump overcall need extra strength", () {
+      // 10 points was a free 3-level advance opposite a sound overcall,
+      // but partner's jump showed only 5-9.
+      expect(
+          openingBid("Q9762", "Q", "QT743", "Q5",
+              history: ["1H", "3C", "3H"]),
+          "Pass");
+    });
   });
 
   group("competitive continuations", () {
@@ -1618,6 +1743,19 @@ void main() {
       expect(invite.meaning.totalPoints, const Range(high: 11));
       // With real game values, bid it.
       expect(openingBid("AJ4", "AKJ32", "432", "32", history: h), "4H");
+    });
+
+    test("an action double converts to penalties only with trump tricks", () {
+      expect(
+          openingBid("Q5", "AKJ85", "K42", "J53",
+              history: ["1H", "pass", "2H", "2S", "pass", "pass", "X",
+                        "pass"]),
+          "3H"); // doubleton: pull to the known fit
+      expect(
+          openingBid("QT85", "AKJ85", "K42", "3",
+              history: ["1H", "pass", "2H", "2S", "pass", "pass", "X",
+                        "pass"]),
+          "Pass"); // four trumps: defend
     });
   });
 

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -883,6 +883,19 @@ void main() {
           "4C"); // diamonds unstopped: the raise stands
     });
 
+    test("off-book balanced 15-17 bids game over a two-level response", () {
+      // A balanced 15-17 would normally have opened 1NT; if it opened the
+      // suit instead, the forcing 10+ response makes game values, and the
+      // 2NT rebid must not claim 12-14.
+      final result = selectSaycBid(hand("KQJ32", "A32", "K3", "QJ3"),
+          ["1S", "pass", "2C", "pass"].map(BidAction.fromString).toList());
+      expect(result.action.toString(), "3NT"); // 16 HCP, only 3 clubs
+      expect(result.meaning.hcp, const Range(low: 15, high: 17));
+      expect(openingBid("KQ432", "A32", "K3", "J53",
+              history: ["1S", "pass", "2C", "pass"]),
+          "2NT"); // 13: the genuine 12-14 rebid
+    });
+
     test("opener raises the 16+ 3NT response to slam with 17", () {
       expect(openingBid("Q65", "AK8", "AKJ", "A754",
               history: ["1C", "pass", "3NT", "pass"]),

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -655,11 +655,13 @@ void main() {
           "4D");
     });
 
-    test("minor preempts can be raised and 3NT needs only 15 with a fit", () {
+    test("minor preempt raises: 3NT with the side suits stopped, else 5C", () {
       expect(openingBid("A64", "K6", "JT965", "AKT", history: ["3C", "pass"]),
-          "3NT"); // 15 HCP with a fit: partner's suit will run
-      expect(openingBid("A4", "KJ42", "-", "AQT9832", history: ["3C", "pass"]),
-          "5C"); // 17 total, huge fit, too few HCP for notrump
+          "3NT"); // 15 HCP, a fit, and every side suit stopped
+      expect(openingBid("A4", "KQJ42", "K2", "A932", history: ["3C", "pass"]),
+          "3NT"); // 17 HCP, all stopped: nine tricks before eleven
+      expect(openingBid("A4", "KQJ42", "32", "AK93", history: ["3C", "pass"]),
+          "5C"); // same values, diamonds unstopped: 3NT is unsafe
     });
   });
 


### PR DESCRIPTION
Fixed bidding bugs and missing logic:
- Blackwood asker didn't sign off with a pass when the response was the correct suit, instead it raised to slam missing 2+ aces.
- After 1S/2H, opener will raise with 3 hearts in preference to rebidding spades.
- After 1S/2C, opener will bid 3NT with 16-18 points and stoppers. Unbalanced hands still bid 4C, and responder needs more than a minimum to raise to 5C (previously it always did).
- RONF over weak twos: new suit is forcing for one round.
- Responder can raise 3C/3D preempts to 3NT or 5C/5D with a strong hand.
- Bids slams in more cases with known 33+ combined points.
- Passing an action double for penalty requires stronger trumps.