### PR TITLE
Improve display of hands after bridge round

### DIFF
--- a/lib/bridge_ui.dart
+++ b/lib/bridge_ui.dart
@@ -733,6 +733,7 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
             playerIndex: p,
             cards: round.originalHandForPlayer(p),
             highlightedCards: [],
+            leaveAvatarSpace: false,
           ))
         .toList();
     return MultiplePlayerHandCards(


### PR DESCRIPTION
Set `leaveAvatarSpace: false` to give the opponent hands more room