### PR TITLE
Read free memory from /proc/meminfo in DDS on Linux

### DIFF
--- a/cpp/dds_shim.cpp
+++ b/cpp/dds_shim.cpp
@@ -28,16 +28,12 @@ static int usableThreads = 0;
 extern "C" void DdsEnsureInit() {
   static std::once_flag flag;
   std::call_once(flag, [] {
-    // Bound total memory on every platform. SetMaxThreads(n) is just
-    // SetResources(0, n): with no cap DDS budgets 70% of free RAM (or,
-    // on macOS/Windows, of physical RAM) and sizes its per-thread
-    // transposition tables from that, up to 160MB per thread -- on a
-    // 16-core desktop that is ~2.5GB for a card game. DDS treats the
-    // figure as +30% (332MB) and needs 30MB per small-table thread, so
-    // this yields min(cores, 11) small threads. Each slot serves one
+    // Bound total memory on every platform. DDS treats the figure as
+    // +30% (332MB) and needs 30MB per small-table thread, so this
+    // yields min(cores, 11) small threads. Each slot serves one
     // caller at a time; the app never has more than a few solves in
     // flight, and a small table is plenty for single-deal solves.
-    // Benchmarking (on an M4 Mac) shows that small tables are at worst
+    // Benchmarking on an M4 Mac shows that small tables are at worst
     // 10% slower than large tables, so using more memory wouldn't help.
     SetResources(256, DDS_SHIM_MAX_THREADS);
     DDSInfo info;

--- a/cpp/dds_shim.cpp
+++ b/cpp/dds_shim.cpp
@@ -28,13 +28,18 @@ static int usableThreads = 0;
 extern "C" void DdsEnsureInit() {
   static std::once_flag flag;
   std::call_once(flag, [] {
-#ifdef __ANDROID__
-    // On mobile, bound total memory: DDS otherwise sizes its per-thread
-    // transposition tables from free RAM (up to 160MB per thread).
+    // Bound total memory on every platform. SetMaxThreads(n) is just
+    // SetResources(0, n): with no cap DDS budgets 70% of free RAM (or,
+    // on macOS/Windows, of physical RAM) and sizes its per-thread
+    // transposition tables from that, up to 160MB per thread -- on a
+    // 16-core desktop that is ~2.5GB for a card game. DDS treats the
+    // figure as +30% (332MB) and needs 30MB per small-table thread, so
+    // this yields min(cores, 11) small threads. Each slot serves one
+    // caller at a time; the app never has more than a few solves in
+    // flight, and a small table is plenty for single-deal solves.
+    // Benchmarking (on an M4 Mac) shows that small tables are at worst
+    // 10% slower than large tables, so using more memory wouldn't help.
     SetResources(256, DDS_SHIM_MAX_THREADS);
-#else
-    SetMaxThreads(DDS_SHIM_MAX_THREADS);
-#endif
     DDSInfo info;
     GetDDSInfo(&info);
     usableThreads = info.noOfThreads;

--- a/third_party/dds/README.md
+++ b/third_party/dds/README.md
@@ -1,15 +1,35 @@
 # dds (vendored)
 
-Bo Haglund's double dummy solver, vendored verbatim from
+Bo Haglund's double dummy solver, vendored from
 https://github.com/dds-bridge/dds at tag `v2.9.0`
 (commit 8d75755c8df81999557758c9757514edb94017bc), so that app builds
 with the native DD backend are hermetic.
 
 Contents: `LICENSE` (Apache 2.0), `include/`, and the `.cpp`/`.h` files
 from `src/`. Build-system files, Windows resources, and docs from the
-upstream repository are omitted; **no source files are modified**.
-Local additions live outside this directory: the isolate-safety shim is
-`cpp/dds_shim.cpp`, and `cpp/build_libdds.sh`
+upstream repository are omitted.
+
+**Local patches** (one; marked inline with a `LOCAL PATCH` comment, so
+`git diff` against upstream stays readable): `System::GetHardware` in
+`src/System.cpp` reads free memory from `/proc/meminfo` instead of
+`popen("free -k | tail -n+3 | head -n1 | awk '{print $NF}'")`.
+Upstream's command reads the `-/+ buffers/cache` line that procps
+dropped in 3.3.10, so on a current distribution line 3 is `Swap:` and
+the command returns free *swap* — zero on a machine without swap.
+`SetResources` then budgets zero memory, configures zero threads, and
+the first solve aborts the whole process with `Memory::GetPtr: 0 vs.
+0`.
+
+Android is unaffected by the original bug, since toybox's `free` still
+prints the old three-line layout and the parse lands on the field
+upstream intended — but that is coincidence, not a contract, and the
+patch applies there too (Android compiles this same `__linux__`
+branch). It changes nothing in practice for Android builds: both
+figures sit far above the 256 MB that `DdsEnsureInit` already caps
+`SetResources` at.
+
+Other local additions live outside this directory: the isolate-safety
+shim is `cpp/dds_shim.cpp`, and `cpp/build_libdds.sh`
 builds the library for macOS (`native/`) and Android (`jniLibs/`).
 
 Version note: v2.9.0 rather than the newer DDS3 line by choice — DDS3

--- a/third_party/dds/src/System.cpp
+++ b/third_party/dds/src/System.cpp
@@ -223,13 +223,58 @@ void System::GetHardware(
 #endif
 
 #ifdef __linux__
-  // The code for linux was suggested by Antony Lee.
-  FILE * fifo = popen(
-    "free -k | tail -n+3 | head -n1 | awk '{print $NF}'", "r");
-  int ignore = fscanf(fifo, "%llu", &kilobytesFree);
-  fclose(fifo);
+  // LOCAL PATCH (see third_party/dds/README.md). Upstream ran
+  //   free -k | tail -n+3 | head -n1 | awk '{print $NF}'
+  // which read the "-/+ buffers/cache" line of procps before 3.3.10.
+  // Current procps has no such line, so line 3 is "Swap:" and the
+  // command returns free swap -- zero on a machine without swap, after
+  // which SetResources configures zero threads and the first solve
+  // aborts in Memory::GetPtr. Android happens to be unaffected: its
+  // toybox "free" still prints the old three-line layout, so the parse
+  // lands on the intended field. That is luck, not contract. Read
+  // /proc/meminfo directly, which both implementations are reporting
+  // from anyway, and which is cheaper than a popen.
+  FILE * meminfo = fopen("/proc/meminfo", "r");
+  if (meminfo)
+  {
+    char line[256];
+    unsigned long long avail = 0, memFree = 0, buffers = 0, cached = 0, v;
+    while (fgets(line, sizeof line, meminfo))
+    {
+      if (sscanf(line, "MemAvailable: %llu kB", &v) == 1)
+        avail = v;
+      else if (sscanf(line, "MemFree: %llu kB", &v) == 1)
+        memFree = v;
+      else if (sscanf(line, "Buffers: %llu kB", &v) == 1)
+        buffers = v;
+      else if (sscanf(line, "Cached: %llu kB", &v) == 1)
+        cached = v;
+    }
+    fclose(meminfo);
+    kilobytesFree = (avail > 0 ? avail : memFree + buffers + cached);
+  }
+
+  if (kilobytesFree == 0)
+  {
+    // No readable /proc: fall back to the free physical pages that the
+    // C library reports.
+    const long pages = sysconf(_SC_AVPHYS_PAGES);
+    const long pageSize = sysconf(_SC_PAGESIZE);
+    if (pages > 0 && pageSize > 0)
+      kilobytesFree = static_cast<unsigned long long>(pages) *
+        static_cast<unsigned long long>(pageSize) / 1024;
+  }
+
+  // SetResources budgets 70% of this figure and needs
+  // THREADMEM_SMALL_MAX_MB per thread; below that it configures zero
+  // threads and every solve aborts. Keep room for one small thread even
+  // when the reported figure is unusable.
+  if (kilobytesFree < 1024 * 2 * THREADMEM_SMALL_MAX_MB)
+    kilobytesFree = 1024 * 2 * THREADMEM_SMALL_MAX_MB;
 
   ncores = sysconf(_SC_NPROCESSORS_ONLN);
+  if (ncores < 1)
+    ncores = 1;
   return;
 #endif
 }


### PR DESCRIPTION
Previously DDS read free memory on Linux (including Android) by shelling out to `free` and reading the third line. The output format changed a while back, making the third line the swap size, which if zero would cause a crash. (Android's `free` implementation uses the format DDS expected, so it worked fine). Now reads /proc/meminfo which is more reliable and doesn't need an extra process.

Also sets 256MB max for DDS on all platforms, which doesn't noticeably affect performance.