### PR TITLE
Bidding fixes in competitive auctions

### DIFF
--- a/lib/bridge/sayc/README.md
+++ b/lib/bridge/sayc/README.md
@@ -351,7 +351,7 @@ dart run scripts/bidding_audit.dart --deals 5000 --chaos 0.15
 DDS_LIB=native/libdds.dylib dart run scripts/bidding_accuracy.dart --deals 1200
 ```
 
-### Audit conventions and current results (2026-08-26)
+### Audit conventions and current results (2026-08-30)
 
 Seed 1 over 3000 deals is the held-out **test set**: fixes are mined from
 other seeds (42 at 4000 deals is the current dev seed) so that seed 1 stays
@@ -360,12 +360,12 @@ down as gaps get fixed; a jump up means a regression.
 
 | Run | Result |
 | --- | --- |
-| seed 1, 3000 deals (test set) | 655 findings, 0 hard failures |
-| seed 42, 4000 deals (dev) | 895 findings, 0 hard failures |
+| seed 1, 3000 deals (test set) | 653 findings, 0 hard failures |
+| seed 42, 4000 deals (dev) | 889 findings, 0 hard failures |
 | chaos 0.15, 5000 deals | 0 hard failures |
 
-Seed 1 findings by category: fallback-used 433, missed-game 136,
-silly-strain 51, missed-slam 25, thin-game 1, no-rule-matched 1.
+Seed 1 findings by category: fallback-used 433, missed-game 143,
+silly-strain 50, missed-slam 25, thin-game 1, no-rule-matched 1.
 Fallback-used is monitoring, not failure. The missed-game lint excuses
 stops below game when an opponent-bid suit is unstopped, there is no
 eight-card major fit, and the side holds under 28 points (no game is

--- a/lib/bridge/sayc/README.md
+++ b/lib/bridge/sayc/README.md
@@ -361,7 +361,7 @@ down as gaps get fixed; a jump up means a regression.
 | Run | Result |
 | --- | --- |
 | seed 1, 3000 deals (test set) | 653 findings, 0 hard failures |
-| seed 42, 4000 deals (dev) | 889 findings, 0 hard failures |
+| seed 42, 4000 deals (dev) | 888 findings, 0 hard failures |
 | chaos 0.15, 5000 deals | 0 hard failures |
 
 Seed 1 findings by category: fallback-used 433, missed-game 143,

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -4482,6 +4482,29 @@ List<SaycRule> interferenceResponseRules(
               (isMajor || !h.hasStopper(theirSuit)),
         );
   if (isMajor && cueRule != null) raiseRules.add(cueRule);
+  // A jump overcall that leaves no cue below game (e.g. 1H 3S): the
+  // game-forcing raise bids the game itself. A major with 3+ support goes
+  // straight to four; a minor with 4+ support and no stopper bids four of
+  // the minor, which opener raises with extras (see
+  // [jumpOvercallRaiseRebidRules]).
+  final noCueGameRaise = cueRule != null || cheapest != 4
+      ? null
+      : SaycRule(
+          BidAction.contract(4, suit),
+          BidMeaning(
+            description: isMajor
+                ? "Raise to game: 3+ $name, 13+ points (no cue bid available)"
+                : "Raise to four $name: 4+ $name, 13+ points, no ${_suitNames[theirSuit]} stopper",
+            totalPoints: const Range(low: 13),
+            suitLengths: {suit: Range(low: minSupport)},
+          ),
+          ignoreInfo: true,
+          require: (h) =>
+              h.count(suit) >= minSupport &&
+              h.totalPoints >= 13 &&
+              (isMajor || !h.hasStopper(theirSuit)),
+        );
+  if (isMajor && noCueGameRaise != null) raiseRules.add(noCueGameRaise);
   final negDouble = _negativeDoubleRule(opening, overcall);
 
   final rules = <SaycRule>[
@@ -4540,6 +4563,7 @@ List<SaycRule> interferenceResponseRules(
     ));
   }
   if (!isMajor && cueRule != null) rules.add(cueRule);
+  if (!isMajor && noCueGameRaise != null) rules.add(noCueGameRaise);
 
   // Notrump with a stopper in the overcalled suit.
   final overcallSuit = overcall.trump!;
@@ -5407,6 +5431,32 @@ List<SaycRule>? cueBidRaiseRebidRules(
             totalPoints: const Range(high: 14)),
         ignoreInfo: true,
       ),
+  ];
+}
+
+/// Opener's rebid after a jump overcall took away the cue and responder
+/// raised a minor to four (4+ support, 13+, no stopper in their suit; see
+/// [interferenceResponseRules]). Five needs extras; otherwise the four-level
+/// partscore is the accepted stop with no stopper for notrump.
+List<SaycRule> jumpOvercallRaiseRebidRules(
+    ContractBid opening, ContractBid overcall) {
+  final suit = opening.trump!;
+  final name = _suitNames[suit]!;
+  return [
+    SaycRule(
+      BidAction.contract(5, suit),
+      BidMeaning(
+          description: "Game in $name with extras opposite the four-level raise",
+          totalPoints: const Range(low: 15)),
+      ignoreInfo: true,
+      require: (h) => h.totalPoints >= 15,
+    ),
+    SaycRule(
+      BidAction.pass(),
+      BidMeaning(
+          description: "Minimum opposite the four-level raise; no stopper for notrump",
+          totalPoints: const Range(high: 14)),
+    ),
   ];
 }
 
@@ -6887,6 +6937,19 @@ List<SaycRule>? saycRulesForAuction(List<BidAction> calls) {
             ? rho.contractBid!
             : calls[first + 2].contractBid!);
     if (rules != null) return rules;
+  }
+  if (n == first + 4 &&
+      isOneLevelSuitOpening(opening) &&
+      !_isMajor(opening.contractBid!.trump!) &&
+      isSuitBid(calls[first + 1]) &&
+      cheapestLevel(calls[first + 1].contractBid!.trump!,
+              calls[first + 1].contractBid!) > 3 &&
+      calls[first + 2] == BidAction.contract(4, opening.contractBid!.trump!) &&
+      calls[first + 3].bidType == BidType.pass) {
+    // Their jump overcall took away the cue; partner's 4m is the
+    // game-forcing raise with no stopper.
+    return jumpOvercallRaiseRebidRules(
+        opening.contractBid!, calls[first + 1].contractBid!);
   }
   if (n == first + 4 && calls[first + 3].bidType == BidType.pass) {
     final overcall = calls[first + 1];

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -5268,24 +5268,102 @@ List<SaycRule> reopeningDoubleAdvanceRules(
   if (level > 3) return base;
   // Unlike a direct takeout double, the reopening doubler has shown a real
   // suit by opening it; with 3+ support prefer the known fit to a possibly
-  // unsupported "best suit" (often at a higher level). Having passed the
-  // opening, the hand is too weak for anything more than the preference.
-  // The penalty pass stays ahead of it.
-  final preference = SaycRule(
-    BidAction.contract(level, oSuit),
-    BidMeaning(
-      description: "Returning to opener's ${_suitNames[oSuit]} with support",
-      totalPoints: const Range(high: 8),
-      suitLengths: {oSuit: const Range(low: 3)},
+  // unsupported "best suit" (often at a higher level). The strength tiers
+  // mirror the generic advance: a cheap preference, an invitational jump
+  // when it lands below game, and game with 12+. The initial pass usually
+  // caps the hand well below game values, but a 3-card raise that had no
+  // direct bid (e.g. 9 points over a two-level overcall) is common.
+  // The penalty pass stays ahead of all of them.
+  final name = _suitNames[oSuit]!;
+  final jumpBelowGame = level + 1 < 4;
+  final cheapMax = jumpBelowGame ? 8 : 11;
+  final preferences = <SaycRule>[
+    SaycRule(
+      BidAction.contract(4, oSuit),
+      BidMeaning(
+        description: "Game preference: 3+ $name, 12+ points",
+        totalPoints: const Range(low: 12),
+        suitLengths: {oSuit: const Range(low: 3)},
+      ),
+      ignoreInfo: true,
+      require: (h) => h.count(oSuit) >= 3 && h.totalPoints >= 12,
     ),
-    ignoreInfo: true,
-    require: (h) => h.count(oSuit) >= 3 && h.totalPoints <= 8,
-  );
+    if (jumpBelowGame)
+      SaycRule(
+        BidAction.contract(level + 1, oSuit),
+        BidMeaning(
+          description:
+              "Jump preference: 3+ $name, 9-11 points, invitational",
+          totalPoints: const Range(low: 9, high: 11),
+          suitLengths: {oSuit: const Range(low: 3)},
+        ),
+        ignoreInfo: true,
+        require: (h) =>
+            h.count(oSuit) >= 3 && h.totalPoints >= 9 && h.totalPoints <= 11,
+      ),
+    SaycRule(
+      BidAction.contract(level, oSuit),
+      BidMeaning(
+        description: "Returning to opener's $name with support, 0-$cheapMax points",
+        totalPoints: Range(high: cheapMax),
+        suitLengths: {oSuit: const Range(low: 3)},
+      ),
+      ignoreInfo: true,
+      require: (h) => h.count(oSuit) >= 3 && h.totalPoints <= cheapMax,
+    ),
+  ];
   final passIndex = base.indexWhere((r) => r.action == BidAction.pass());
   return [
     ...base.take(passIndex + 1),
-    preference,
+    ...preferences,
     ...base.skip(passIndex + 1),
+  ];
+}
+
+/// Opener's call after reopening with a double and hearing partner return
+/// to the opened major (see [reopeningDoubleAdvanceRules] for the tiers
+/// partner's preference can show). Returns null for other advances, which
+/// the fallback bidder handles.
+List<SaycRule>? reopeningDoubleContinuationRules(
+    ContractBid opening, ContractBid overcall, ContractBid advance) {
+  final oSuit = opening.trump;
+  if (oSuit == null || !_isMajor(oSuit) || advance.trump != oSuit) {
+    return null;
+  }
+  final name = _suitNames[oSuit]!;
+  final level = cheapestLevel(oSuit, overcall);
+  if (advance.count >= 4) {
+    return [
+      SaycRule(BidAction.pass(),
+          BidMeaning(description: "Partner bid the game; nothing to add")),
+    ];
+  }
+  // Partner's range and the strength we need opposite it: the 9-11 jump
+  // wants a sound 16; the cheap preference is 0-8 (or 0-11 when the jump
+  // would have been game) and only a big hand tries for game opposite it.
+  final isJump = advance.count == level + 1;
+  final int partnerLow = isJump ? 9 : 0;
+  final int partnerHigh = isJump ? 11 : (level + 1 < 4 ? 8 : 11);
+  final int gameMin = isJump ? 16 : (partnerHigh == 8 ? 19 : 18);
+  return [
+    SaycRule(
+      BidAction.contract(4, oSuit),
+      BidMeaning(
+        description:
+            "Bidding game opposite the $partnerLow-$partnerHigh preference",
+        totalPoints: Range(low: gameMin),
+      ),
+      ignoreInfo: true,
+      require: (h) => h.totalPoints >= gameMin,
+    ),
+    SaycRule(
+      BidAction.pass(),
+      BidMeaning(
+        description:
+            "Not enough for game opposite the $partnerLow-$partnerHigh $name preference",
+        totalPoints: Range(high: gameMin - 1),
+      ),
+    ),
   ];
 }
 
@@ -6633,6 +6711,20 @@ List<SaycRule>? saycRulesForAuction(List<BidAction> calls) {
     // doubled: choose between penalties and the cheapest fit.
     return actionDoubleAdvanceRules(opening.contractBid!,
         calls[first + 2].contractBid!, calls[first + 3].contractBid!);
+  }
+  if (n == first + 8 &&
+      isOneLevelSuitOpening(opening) &&
+      isSuitBid(calls[first + 1]) &&
+      calls[first + 2].bidType == BidType.pass &&
+      calls[first + 3].bidType == BidType.pass &&
+      calls[first + 4].bidType == BidType.double &&
+      calls[first + 5].bidType == BidType.pass &&
+      calls[first + 6].bidType == BidType.contract &&
+      calls[first + 7].bidType == BidType.pass) {
+    // We reopened with a double and partner advanced.
+    final rules = reopeningDoubleContinuationRules(opening.contractBid!,
+        calls[first + 1].contractBid!, calls[first + 6].contractBid!);
+    if (rules != null) return rules;
   }
   if (oppActions.isEmpty) {
     if (n == first + 4) {

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -4457,6 +4457,31 @@ List<SaycRule> interferenceResponseRules(
       ),
     ));
   }
+  // Game-forcing raise without a direct game bid: cue-bid their suit. For
+  // a major this is the normal route with 3-card support (the 5-3 fit is
+  // preferred to 3NT) and ranks with the raises; for a minor it is the hand
+  // with support but no stopper (with a stopper 3NT is bid directly) and
+  // comes after the free bids, so a biddable major is shown first.
+  final theirSuit = overcall.trump!;
+  final cueLevel = cheapestLevel(theirSuit, overcall);
+  final cueRule = cueLevel > 3
+      ? null
+      : SaycRule(
+          BidAction.contract(cueLevel, theirSuit),
+          BidMeaning(
+            description:
+                "Cue bid: $minSupport+ $name, 13+ points, game forcing",
+            totalPoints: const Range(low: 13),
+            suitLengths: {suit: Range(low: minSupport)},
+            artificial: true,
+          ),
+          ignoreInfo: true,
+          require: (h) =>
+              h.count(suit) >= minSupport &&
+              h.totalPoints >= 13 &&
+              (isMajor || !h.hasStopper(theirSuit)),
+        );
+  if (isMajor && cueRule != null) raiseRules.add(cueRule);
   final negDouble = _negativeDoubleRule(opening, overcall);
 
   final rules = <SaycRule>[
@@ -4514,6 +4539,7 @@ List<SaycRule> interferenceResponseRules(
       require: (h) => freeBidChoice(h) == s,
     ));
   }
+  if (!isMajor && cueRule != null) rules.add(cueRule);
 
   // Notrump with a stopper in the overcalled suit.
   final overcallSuit = overcall.trump!;
@@ -5317,6 +5343,99 @@ List<SaycRule> reopeningDoubleAdvanceRules(
     ...base.take(passIndex + 1),
     ...preferences,
     ...base.skip(passIndex + 1),
+  ];
+}
+
+/// Opener's rebid after responder cue-bid the overcalled suit (a game-forcing
+/// raise; see [interferenceResponseRules]). A major has its 5-3 fit: bid the
+/// game. Opposite a minor raise, 3NT with a stopper in their suit, else five
+/// of the minor with extras and four of it (not forcing) as a minimum.
+/// [over] is the last bid (the cue, or LHO's raise of it); returns null when
+/// no game bid is available over it, leaving the decision to the fallback.
+List<SaycRule>? cueBidRaiseRebidRules(
+    ContractBid opening, ContractBid overcall, ContractBid over) {
+  final suit = opening.trump!;
+  final name = _suitNames[suit]!;
+  final theirSuit = overcall.trump!;
+  if (_isMajor(suit)) {
+    if (cheapestLevel(suit, over) > 4) return null;
+    return [
+      SaycRule(
+        BidAction.contract(4, suit),
+        BidMeaning(description: "Game in $name opposite the cue-bid raise"),
+      ),
+    ];
+  }
+  final ntLevel = cheapestLevel(null, over);
+  final suitLevel = cheapestLevel(suit, over);
+  if (suitLevel > 5 && ntLevel > 3) return null;
+  return [
+    if (ntLevel <= 3)
+      SaycRule(
+        BidAction.noTrump(3),
+        BidMeaning(
+            description:
+                "Game in notrump: ${_suitNames[theirSuit]} stopped"),
+        ignoreInfo: true,
+        require: (h) => h.hasStopper(theirSuit),
+      ),
+    if (suitLevel <= 5)
+      SaycRule(
+        BidAction.contract(5, suit),
+        BidMeaning(
+            description:
+                "Game in $name: extras, no ${_suitNames[theirSuit]} stopper",
+            totalPoints: const Range(low: 15)),
+        ignoreInfo: true,
+        require: (h) => h.totalPoints >= 15,
+      ),
+    if (suitLevel <= 4)
+      SaycRule(
+        BidAction.contract(4, suit),
+        BidMeaning(
+            description:
+                "Minimum with no ${_suitNames[theirSuit]} stopper; partner may raise",
+            totalPoints: const Range(high: 14)),
+        ignoreInfo: true,
+      )
+    else
+      SaycRule(
+        BidAction.pass(),
+        BidMeaning(
+            description:
+                "Minimum with no ${_suitNames[theirSuit]} stopper over their raise; the cue keeps this forcing",
+            totalPoints: const Range(high: 14)),
+        ignoreInfo: true,
+      ),
+  ];
+}
+
+/// Responder's call after cue-bidding a raise and hearing opener's choice.
+List<SaycRule> cueBidRaiseResponderRules(
+    ContractBid opening, ContractBid rebid) {
+  final suit = opening.trump!;
+  if (rebid.trump == suit && rebid.count == 4 && !_isMajor(suit)) {
+    // Opener's 4m showed a minimum with no stopper: raise with extras.
+    return [
+      SaycRule(
+        BidAction.contract(5, suit),
+        BidMeaning(
+            description: "Raising to game with extras for the cue bid",
+            totalPoints: const Range(low: 16)),
+        ignoreInfo: true,
+        require: (h) => h.totalPoints >= 16,
+      ),
+      SaycRule(
+        BidAction.pass(),
+        BidMeaning(
+            description: "Minimum for the cue bid; no stopper for notrump",
+            totalPoints: const Range(high: 15)),
+      ),
+    ];
+  }
+  return [
+    SaycRule(BidAction.pass(),
+        BidMeaning(description: "Partner chose the game over the cue bid")),
   ];
 }
 
@@ -6668,6 +6787,13 @@ List<SaycRule>? saycRulesForAuction(List<BidAction> calls) {
                         "Respecting partner's decision over our natural 2NT"))
           ];
         }
+        if (suitOpening &&
+            isSuitBid(rho1) &&
+            myResponse.contractBid!.trump == rho1.contractBid!.trump) {
+          // Our cue bid of their suit was a game-forcing raise.
+          return cueBidRaiseResponderRules(
+              opening.contractBid!, partnerRebid.contractBid!);
+        }
         // Both calls were natural bids: the uncontested continuation logic
         // applies (levels adapt via the actual calls).
         return responderRebidRules(opening, myResponse, partnerRebid,
@@ -6744,6 +6870,23 @@ List<SaycRule>? saycRulesForAuction(List<BidAction> calls) {
     // bidding space and partner's new suit is still forcing, so rebid
     // exactly as if there were no interference (systems on).
     return openerRebidRules(opening, calls[first + 2]);
+  }
+  if (n == first + 4 &&
+      isOneLevelSuitOpening(opening) &&
+      isSuitBid(calls[first + 1]) &&
+      calls[first + 2].bidType == BidType.contract &&
+      calls[first + 2].contractBid!.trump == calls[first + 1].contractBid!.trump &&
+      calls[first + 3].bidType != BidType.double) {
+    // Partner cue-bid their suit: a game-forcing raise of our suit. RHO may
+    // have raised over it.
+    final rho = calls[first + 3];
+    final rules = cueBidRaiseRebidRules(
+        opening.contractBid!,
+        calls[first + 1].contractBid!,
+        rho.bidType == BidType.contract
+            ? rho.contractBid!
+            : calls[first + 2].contractBid!);
+    if (rules != null) return rules;
   }
   if (n == first + 4 && calls[first + 3].bidType == BidType.pass) {
     final overcall = calls[first + 1];

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1838,6 +1838,46 @@ void main() {
       expect(openingBid("Q87", "97", "K54", "85432", history: h), "3C");
     });
 
+    test("reopening-double advance with support and invitational values", () {
+      // Manual-play hand: 9 points with 3-card support jumped to 4D in a
+      // 4-card suit instead of bidding the known heart fit.
+      expect(openingBid("T62", "K95", "JT87", "AJ6",
+              history: ["1H", "2S", "pass", "pass", "X", "pass"]),
+          "3H");
+      // With room below game, 9-11 jumps in opener's suit to invite and
+      // 12+ bids the game; weaker hands take the cheap preference.
+      final h = ["1H", "1S", "pass", "pass", "X", "pass"];
+      expect(openingBid("T62", "K95", "JT87", "AJ6", history: h), "3H");
+      expect(openingBid("T62", "K95", "JT87", "A96", history: h), "2H");
+      expect(openingBid("T62", "K95", "KQ87", "AJ6", history: h), "4H");
+      // Spade stack still passes for penalty ahead of the preference.
+      expect(openingBid("KQJ9", "K95", "JT87", "A6", history: h), "Pass");
+    });
+
+    test("reopening doubler continues over partner's preference", () {
+      // Jump preference shows 9-11: accept with 16+, else pass.
+      final jump = ["1H", "1S", "pass", "pass", "X", "pass", "3H", "pass"];
+      expect(openingBid("K4", "AQJ73", "Q65", "872", history: jump),
+          "Pass"); // 13 total
+      expect(openingBid("K4", "AQJ73", "A65", "Q72", history: jump),
+          "4H"); // 17 total
+      // The cheap preference over a one-level overcall is 0-8: pass short
+      // of a big hand.
+      final cheap = ["1H", "1S", "pass", "pass", "X", "pass", "2H", "pass"];
+      expect(openingBid("K4", "AQJ73", "A65", "Q72", history: cheap), "Pass");
+      expect(openingBid("K4", "AQJ73", "A65", "KQ2", history: cheap),
+          "4H"); // 20 total
+      // Over a two-level overcall the 3H preference covers 0-11.
+      final wide = ["1H", "2S", "pass", "pass", "X", "pass", "3H", "pass"];
+      expect(openingBid("K4", "AQJ73", "A65", "Q72", history: wide), "Pass");
+      expect(openingBid("K4", "AQJ73", "A65", "K72", history: wide),
+          "4H"); // 18 total
+      // Partner's game bid ends it.
+      expect(openingBid("A4", "AQJ73", "A65", "KQ2",
+              history: ["1H", "1S", "pass", "pass", "X", "pass", "4H", "pass"]),
+          "Pass");
+    });
+
     test("overcaller shows a second suit over the new-suit advance", () {
       // Self-play deal 3606 (seed 42): 5-5 with 17 total passed the 2C
       // advance with "no descriptive rebid".

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1875,6 +1875,26 @@ void main() {
           "1S");
     });
 
+    test("game raise with 3-card support when the jump overcall takes the cue",
+        () {
+      // Manual-play hand: over 1H 3S the cue would be 4S, so a 3-card
+      // game-forcing raise bids the game directly.
+      expect(openingBid("T62", "K95", "AT87", "AK6", history: ["1H", "3S"]),
+          "4H");
+      // Minor: 4m with support and no stopper, 3NT with one; opener raises
+      // the 4m game try only with extras.
+      expect(openingBid("T62", "K9", "AT875", "AK6", history: ["1D", "3S"]),
+          "4D");
+      expect(openingBid("A62", "K9", "QT875", "AK6", history: ["1D", "3S"]),
+          "3NT");
+      final h = ["1D", "3S", "4D", "pass"];
+      expect(openingBid("43", "K7", "AQJ73", "KQ72", history: h), "5D");
+      expect(openingBid("43", "K7", "AQJ73", "Q872", history: h), "Pass");
+      expect(openingBid("K4", "AQJ73", "Q65", "872",
+              history: ["1H", "3S", "4H", "pass"]),
+          "Pass");
+    });
+
     test("opener still places the game when LHO raises over the cue", () {
       // Self-play deals 1814 and 429 (seed 1).
       expect(openingBid("A9", "AQ9", "KT64", "8754",

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1854,6 +1854,64 @@ void main() {
       expect(openingBid("KQJ9", "K95", "JT87", "A6", history: h), "Pass");
     });
 
+    test("cue bid over the overcall shows a game-forcing raise", () {
+      // Manual-play hand: 15 HCP with 3-card support passed 2S because the
+      // game raise needs four trumps and 3NT needs a spade stopper.
+      expect(openingBid("T62", "K95", "AT87", "AK6", history: ["1H", "2S"]),
+          "3S");
+      expect(openingBid("T62", "K95", "AT87", "AK6", history: ["1S", "2H"]),
+          "3H");
+      // Four trumps still raise to game directly.
+      expect(openingBid("T6", "K952", "AT87", "AK6", history: ["1H", "2S"]),
+          "4H");
+      // Minor opening: cue with support and no stopper, 3NT with one.
+      expect(openingBid("T62", "K9", "AT875", "AK6", history: ["1D", "2S"]),
+          "3S");
+      expect(openingBid("A62", "K9", "QT875", "AK6", history: ["1D", "2S"]),
+          "3NT");
+      // Opposite a minor a one-level major comes ahead of the cue (self-play
+      // deal 429, seed 1).
+      expect(openingBid("J8532", "Q2", "AKQ6", "63", history: ["1D", "1H"]),
+          "1S");
+    });
+
+    test("opener still places the game when LHO raises over the cue", () {
+      // Self-play deals 1814 and 429 (seed 1).
+      expect(openingBid("A9", "AQ9", "KT64", "8754",
+              history: ["1D", "1S", "2S", "3S"]),
+          "3NT");
+      expect(openingBid("AK", "6", "T9842", "KJT87",
+              history: ["1D", "1H", "2H", "3H"]),
+          "4D");
+      expect(openingBid("K4", "AQJ73", "Q65", "872",
+              history: ["1H", "2S", "3S", "4C"]),
+          "4H");
+    });
+
+    test("opener and responder continue after the cue-bid raise", () {
+      final major = ["1H", "2S", "3S", "pass"];
+      expect(openingBid("K4", "AQJ73", "Q65", "872", history: major), "4H");
+      expect(openingBid("T62", "K95", "AT87", "AK6",
+              history: [...major, "4H", "pass"]),
+          "Pass");
+      final minor = ["1D", "2S", "3S", "pass"];
+      expect(openingBid("A43", "K7", "AQJ73", "872", history: minor),
+          "3NT"); // spade stopper
+      expect(openingBid("43", "K7", "AQJ73", "KQ72", history: minor),
+          "5D"); // 16 total, no stopper
+      expect(openingBid("43", "K7", "AQJ73", "Q872", history: minor),
+          "4D"); // minimum, no stopper
+      expect(openingBid("T62", "K9", "AT875", "AKJ",
+              history: [...minor, "4D", "pass"]),
+          "5D"); // 16 total accepts
+      expect(openingBid("T62", "K9", "AT875", "AK6",
+              history: [...minor, "4D", "pass"]),
+          "Pass"); // 15 total
+      expect(openingBid("T62", "K9", "AT875", "AK6",
+              history: [...minor, "3NT", "pass"]),
+          "Pass");
+    });
+
     test("reopening doubler continues over partner's preference", () {
       // Jump preference shows 9-11: accept with 16+, else pass.
       final jump = ["1H", "1S", "pass", "pass", "X", "pass", "3H", "pass"];


### PR DESCRIPTION
- After reopening double, prefer partner's major with 3+ support rather than bidding a new suit
- Cue-bid overcalled suit as a game-forcing raise
- Raise directly to game if cuebid isn't possible (e.g. 3S overcall of 1H)