### PR TITLE
Show double-dummy mistakes when reviewing play

### DIFF
--- a/lib/bridge/bridge_ai.dart
+++ b/lib/bridge/bridge_ai.dart
@@ -720,7 +720,6 @@ LinkedHashMap<PlayingCard, int>? doubleDummyResultForAllCards({
   if (tricksForCard == null) {
     return null;
   }
-  final result = LinkedHashMap<PlayingCard, int>();
   final sortedCards = [...tricksForCard.keys];
 
   // For consistency, sort deterministically first by the number of tricks taken,
@@ -730,16 +729,18 @@ LinkedHashMap<PlayingCard, int>? doubleDummyResultForAllCards({
   }
 
   sortedCards.sort((a, b) => sortVal(b) - sortVal(a));
+  final result = LinkedHashMap<PlayingCard, int>();
   for (final c in sortedCards) {
     result[c] = tricksForCard[c]!;
   }
   return result;
 }
 
-// The state of a completed round's play at the point where
-// [cardsInCurrentTrick] cards have been played to trick number
-// [completedTricks] (both zero-based): the cards each player still holds,
-// and the trick in progress.
+// The state of a completed round's play after [completedTricks] tricks have
+// been finished and [cardsInCurrentTrick] further cards have been played to
+// the trick in progress: the cards each player still holds, and that trick.
+// The finished tricks being round.previousTricks[0] through
+// [completedTricks] - 1, the trick in progress is at index [completedTricks].
 ({List<List<PlayingCard>> hands, TrickInProgress currentTrick})
     roundStateAtPointInPlay({
   required BridgeRound round,

--- a/lib/bridge/bridge_ai.dart
+++ b/lib/bridge/bridge_ai.dart
@@ -1,4 +1,5 @@
 import "dart:math";
+import "dart:collection";
 
 import "package:cards_with_cats/cards/card.dart";
 
@@ -692,5 +693,96 @@ MonteCarloResult chooseCardMonteCarloDD(
     numRollouts: numRounds * legalPlays.length,
     numRolloutCardsPlayed: 0,
     elapsedMillis: timeFn() - startTime,
+  );
+}
+
+// Returns an ordered map with the double-dummy result of playing each card
+// in the current player's hand. The ordering will be from highest to lowest
+// number of tricks, so the first entry will be the card that produces the best
+// result (or one of multiple cards that produces the best result).
+// Returns null if the native DDS solver is not available.
+LinkedHashMap<PlayingCard, int>? doubleDummyResultForAllCards({
+  required TrickInProgress currentTrick,
+  required List<List<PlayingCard>> hands,
+  required Suit? trump,
+}) {
+  final dds = DdsBackend.instance;
+  if (dds == null) {
+    return null;
+  }
+  final tricksForCard = <PlayingCard, int>{};
+  final currentPlayer = (currentTrick.leader + currentTrick.cards.length) % 4;
+  // Play each card and then compute the double-dummy result for the next player.
+  List<List<PlayingCard>> handsAfterCard = [...hands];
+  final candidates = legalPlays(hands[currentPlayer], currentTrick);
+  for (final cardToPlay in candidates) {
+    final remainingCardsForCurrentPlayer = [...hands[currentPlayer]];
+    remainingCardsForCurrentPlayer.remove(cardToPlay);
+    handsAfterCard[currentPlayer] = remainingCardsForCurrentPlayer;
+    // Add the card to the current trick; if it finishes determine the winner and
+    // pass an empty trick to DDS.
+    final updatedTrickCards = [...currentTrick.cards, cardToPlay];
+    int? ddResult;
+    if (currentTrick.cards.length == 3) {
+      // Finish the current trick, the winner becomes the leader to an empty trick.
+      final completedTrick = TrickInProgress(currentTrick.leader, updatedTrickCards);
+      final winner = completedTrick.finish(trump: trump).winner;
+      bool nsWon = winner % 2 == 0;
+      ddResult = dds.solve(handsAfterCard, trump, winner, []);
+      if (ddResult != null) {
+        ddResult += (nsWon ? 1 : 0);;
+      }
+    }
+    else {
+      ddResult = dds.solve(handsAfterCard, trump, currentTrick.leader, updatedTrickCards);
+    }
+    if (ddResult == null) {
+      return null;
+    }
+    // ddResult is N/S tricks, convert to tricks for current player's side.
+    final actualTricksWon = currentPlayer % 2 == 0
+      ? ddResult
+      : hands[currentPlayer].length - ddResult;
+    tricksForCard[cardToPlay] = actualTricksWon;
+  }
+  final result = LinkedHashMap<PlayingCard, int>();
+  final sortedCards = [...tricksForCard.keys];
+  sortedCards.sort((a, b) => tricksForCard[b]! - tricksForCard[a]!);
+  for (final c in sortedCards) {
+    result[c] = tricksForCard[c]!;
+  }
+  return result;
+}
+
+LinkedHashMap<PlayingCard, int>? doubleDummyResultForPreviousPointInRound({
+  required BridgeRound round,
+  required int completedTricks,
+  required int cardsInCurrentTrick,
+}) {
+  if (!round.isOver()) {
+    throw Exception("doubleDummyResultForPreviousPointInRound should only be called for a completed round");
+  }
+  List<List<PlayingCard>> hands = [[], [], [], []];
+  // Assign cards from the current and subsequent tricks, then remove any cards
+  // played in the current trick.
+  for (int ti = completedTricks; ti < 13; ti++) {
+    final trick = round.previousTricks[ti];
+    for (int ci = 0; ci < trick.cards.length; ci++) {
+      final pi = (trick.leader + ci) % trick.cards.length;
+      hands[pi].add(trick.cards[ci]);
+    }
+  }
+  final currentTrick = TrickInProgress(
+      round.previousTricks[completedTricks].leader,
+      round.previousTricks[completedTricks].cards.sublist(0, cardsInCurrentTrick),
+  );
+  for (int ci = 0; ci < cardsInCurrentTrick; ci++) {
+    final pi = (currentTrick.leader + ci) % currentTrick.cards.length;
+    hands[pi].remove(currentTrick.cards[ci]);
+  }
+  return doubleDummyResultForAllCards(
+    currentTrick: currentTrick,
+    hands: hands,
+    trump: round.trumpSuit(),
   );
 }

--- a/lib/bridge/bridge_ai.dart
+++ b/lib/bridge/bridge_ai.dart
@@ -1,5 +1,5 @@
-import "dart:math";
 import "dart:collection";
+import "dart:math";
 
 import "package:cards_with_cats/cards/card.dart";
 
@@ -697,7 +697,10 @@ MonteCarloResult chooseCardMonteCarloDD(
 }
 
 // Returns an ordered map with the double-dummy result of playing each card
-// in the current player's hand. The ordering will be from highest to lowest
+// that the current player can legally play, as the number of tricks that the
+// current player's side takes with optimal play by both sides afterwards.
+// The count includes the trick in progress, so a card that wins the current
+// trick is credited for it. The ordering will be from highest to lowest
 // number of tricks, so the first entry will be the card that produces the best
 // result (or one of multiple cards that produces the best result).
 // Returns null if the native DDS solver is not available.
@@ -710,79 +713,87 @@ LinkedHashMap<PlayingCard, int>? doubleDummyResultForAllCards({
   if (dds == null) {
     return null;
   }
-  final tricksForCard = <PlayingCard, int>{};
-  final currentPlayer = (currentTrick.leader + currentTrick.cards.length) % 4;
-  // Play each card and then compute the double-dummy result for the next player.
-  List<List<PlayingCard>> handsAfterCard = [...hands];
-  final candidates = legalPlays(hands[currentPlayer], currentTrick);
-  for (final cardToPlay in candidates) {
-    final remainingCardsForCurrentPlayer = [...hands[currentPlayer]];
-    remainingCardsForCurrentPlayer.remove(cardToPlay);
-    handsAfterCard[currentPlayer] = remainingCardsForCurrentPlayer;
-    // Add the card to the current trick; if it finishes determine the winner and
-    // pass an empty trick to DDS.
-    final updatedTrickCards = [...currentTrick.cards, cardToPlay];
-    int? ddResult;
-    if (currentTrick.cards.length == 3) {
-      // Finish the current trick, the winner becomes the leader to an empty trick.
-      final completedTrick = TrickInProgress(currentTrick.leader, updatedTrickCards);
-      final winner = completedTrick.finish(trump: trump).winner;
-      bool nsWon = winner % 2 == 0;
-      ddResult = dds.solve(handsAfterCard, trump, winner, []);
-      if (ddResult != null) {
-        ddResult += (nsWon ? 1 : 0);;
-      }
-    }
-    else {
-      ddResult = dds.solve(handsAfterCard, trump, currentTrick.leader, updatedTrickCards);
-    }
-    if (ddResult == null) {
-      return null;
-    }
-    // ddResult is N/S tricks, convert to tricks for current player's side.
-    final actualTricksWon = currentPlayer % 2 == 0
-      ? ddResult
-      : hands[currentPlayer].length - ddResult;
-    tricksForCard[cardToPlay] = actualTricksWon;
+  // A single DDS call scores every legal card for the player on play, and
+  // already reports tricks from that player's side's perspective.
+  final tricksForCard =
+      dds.solveAllCards(hands, trump, currentTrick.leader, currentTrick.cards);
+  if (tricksForCard == null) {
+    return null;
   }
   final result = LinkedHashMap<PlayingCard, int>();
   final sortedCards = [...tricksForCard.keys];
-  sortedCards.sort((a, b) => tricksForCard[b]! - tricksForCard[a]!);
+
+  // For consistency, sort deterministically first by the number of tricks taken,
+  // then by rank (highest first), then by S/H/D/C suit order.
+  int sortVal(PlayingCard c) {
+    return tricksForCard[c]! * 1000 + c.rank.index * 10 + c.suit.index;
+  }
+
+  sortedCards.sort((a, b) => sortVal(b) - sortVal(a));
   for (final c in sortedCards) {
     result[c] = tricksForCard[c]!;
   }
   return result;
 }
 
-LinkedHashMap<PlayingCard, int>? doubleDummyResultForPreviousPointInRound({
+// The state of a completed round's play at the point where
+// [cardsInCurrentTrick] cards have been played to trick number
+// [completedTricks] (both zero-based): the cards each player still holds,
+// and the trick in progress.
+({List<List<PlayingCard>> hands, TrickInProgress currentTrick})
+    roundStateAtPointInPlay({
   required BridgeRound round,
   required int completedTricks,
   required int cardsInCurrentTrick,
 }) {
   if (!round.isOver()) {
-    throw Exception("doubleDummyResultForPreviousPointInRound should only be called for a completed round");
+    throw Exception(
+        "roundStateAtPointInPlay should only be called for a completed round");
   }
-  List<List<PlayingCard>> hands = [[], [], [], []];
+  final numPlayers = round.numberOfPlayers;
+  if (completedTricks < 0 || completedTricks >= round.previousTricks.length) {
+    throw RangeError("No trick at index $completedTricks");
+  }
+  if (cardsInCurrentTrick < 0 || cardsInCurrentTrick >= numPlayers) {
+    throw RangeError(
+        "Invalid number of cards in the current trick: $cardsInCurrentTrick");
+  }
   // Assign cards from the current and subsequent tricks, then remove any cards
   // played in the current trick.
-  for (int ti = completedTricks; ti < 13; ti++) {
+  final hands = List.generate(numPlayers, (_) => <PlayingCard>[]);
+  for (int ti = completedTricks; ti < round.previousTricks.length; ti++) {
     final trick = round.previousTricks[ti];
     for (int ci = 0; ci < trick.cards.length; ci++) {
-      final pi = (trick.leader + ci) % trick.cards.length;
+      final pi = (trick.leader + ci) % numPlayers;
       hands[pi].add(trick.cards[ci]);
     }
   }
-  final currentTrick = TrickInProgress(
-      round.previousTricks[completedTricks].leader,
-      round.previousTricks[completedTricks].cards.sublist(0, cardsInCurrentTrick),
-  );
+  final displayedTrick = round.previousTricks[completedTricks];
+  final currentTrick = TrickInProgress(displayedTrick.leader,
+      displayedTrick.cards.sublist(0, cardsInCurrentTrick));
   for (int ci = 0; ci < cardsInCurrentTrick; ci++) {
-    final pi = (currentTrick.leader + ci) % currentTrick.cards.length;
+    final pi = (currentTrick.leader + ci) % numPlayers;
     hands[pi].remove(currentTrick.cards[ci]);
   }
+  return (hands: hands, currentTrick: currentTrick);
+}
+
+// Returns the double-dummy evaluation of every legal play available to the
+// player who was on play at the given point in a completed round; see
+// [doubleDummyResultForAllCards] for the meaning of the values.
+LinkedHashMap<PlayingCard, int>? doubleDummyResultForPreviousPointInRound({
+  required BridgeRound round,
+  required int completedTricks,
+  required int cardsInCurrentTrick,
+}) {
+  final state = roundStateAtPointInPlay(
+    round: round,
+    completedTricks: completedTricks,
+    cardsInCurrentTrick: cardsInCurrentTrick,
+  );
   return doubleDummyResultForAllCards(
-    currentTrick: currentTrick,
-    hands: hands,
+    currentTrick: state.currentTrick,
+    hands: state.hands,
     trump: round.trumpSuit(),
   );
 }

--- a/lib/bridge/dds_ffi.dart
+++ b/lib/bridge/dds_ffi.dart
@@ -149,11 +149,17 @@ class DdsBackend {
     }
   }
 
-  /// North-South tricks from this position with optimal play, including
-  /// the trick in progress — the same contract as [DDSolver.solve].
-  /// Returns null on a DDS error.
-  int? solve(List<List<PlayingCard>> hands, Suit? trump, int leader,
+  /// Fills the shared deal struct with this position, returning the total
+  /// number of cards still in play (hands plus the trick in progress).
+  ///
+  /// DDS has room for only three cards in the trick in progress; a
+  /// complete trick has to be resolved by the caller before solving.
+  int _fillDeal(List<List<PlayingCard>> hands, Suit? trump, int leader,
       List<PlayingCard> trickCards) {
+    if (trickCards.length > 3) {
+      throw ArgumentError(
+          "Trick in progress can have at most 3 cards, got ${trickCards.length}");
+    }
     final deal = _deal.ref;
     deal.trump = trump == null ? 4 : _ddsSuit(trump);
     deal.first = leader;
@@ -175,13 +181,23 @@ class DdsBackend {
         totalCards++;
       }
     }
+    return totalCards;
+  }
+
+  /// North-South tricks from this position with optimal play, including
+  /// the trick in progress — the same contract as [DDSolver.solve].
+  /// Returns null on a DDS error.
+  int? solve(List<List<PlayingCard>> hands, Suit? trump, int leader,
+      List<PlayingCard> trickCards) {
+    final totalCards = _fillDeal(hands, trump, leader, trickCards);
     final threadIndex = _acquireThreadIndex();
     if (threadIndex < 0) {
       return null; // all DDS slots busy; caller falls back
     }
     final int res;
     try {
-      res = _solveBoard(deal, -1, 1, 1, _fut, threadIndex);
+      // solutions=1: only the best card's score is needed.
+      res = _solveBoard(_deal.ref, -1, 1, 1, _fut, threadIndex);
     } finally {
       _releaseThreadIndex(threadIndex);
     }
@@ -193,5 +209,63 @@ class DdsBackend {
     final mover = (leader + trickCards.length) % 4;
     final remainingTricks = totalCards ~/ 4;
     return mover % 2 == 0 ? score : remainingTricks - score;
+  }
+
+  /// Tricks taken by the side on play for each card that player can legally
+  /// play, with optimal play by both sides afterwards. As with [solve] the
+  /// count includes the trick in progress, so a card that wins the current
+  /// trick is credited for it.
+  ///
+  /// One SolveBoard call evaluates every candidate, which is much cheaper
+  /// than a [solve] per card. Note that the scores are from the perspective
+  /// of the player on play, not of North-South as in [solve].
+  ///
+  /// [trickCards] holds at most three cards; with three, the player on play
+  /// is the one completing the trick.
+  ///
+  /// Returns null on a DDS error or when all solver slots are busy.
+  Map<PlayingCard, int>? solveAllCards(List<List<PlayingCard>> hands,
+      Suit? trump, int leader, List<PlayingCard> trickCards) {
+    _fillDeal(hands, trump, leader, trickCards);
+    final threadIndex = _acquireThreadIndex();
+    if (threadIndex < 0) {
+      return null; // all DDS slots busy; caller falls back
+    }
+    final int res;
+    try {
+      // solutions=3 scores every legal card rather than just the best one.
+      // mode=1 searches even when only one card is playable, so that every
+      // returned score is a real trick count rather than a -1 placeholder.
+      res = _solveBoard(_deal.ref, -1, 3, 1, _fut, threadIndex);
+    } finally {
+      _releaseThreadIndex(threadIndex);
+    }
+    if (res != 1) {
+      return null;
+    }
+    final fut = _fut.ref;
+    nodesSearched += fut.nodes;
+    if (fut.cards <= 0) {
+      return null;
+    }
+    final result = <PlayingCard, int>{};
+    for (int i = 0; i < fut.cards; i++) {
+      final score = fut.score[i];
+      if (score < 0) {
+        return null; // DDS declined to score this card.
+      }
+      final suit = Suit.values[3 - fut.suit[i]];
+      result[PlayingCard(Rank.values[fut.rank[i] - 2], suit)] = score;
+      // DDS returns one entry per equivalence class; `equals` is a bit map
+      // of the lower ranks in the same suit that play identically, with
+      // bit 2 for the two through bit 14 for the ace.
+      final equalRanks = fut.equals[i];
+      for (int r = 2; r <= 14; r++) {
+        if (equalRanks & (1 << r) != 0) {
+          result[PlayingCard(Rank.values[r - 2], suit)] = score;
+        }
+      }
+    }
+    return result;
   }
 }

--- a/lib/bridge_ui.dart
+++ b/lib/bridge_ui.dart
@@ -337,14 +337,14 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
       }
       _updateStatsIfMatchOrRoundOver();
       // Testing
-      if (!round.isOver()) {
-        final ddPlays = doubleDummyResultForAllCards(
-          hands: [for (final p in round.players) p.hand],
-          currentTrick: round.currentTrick,
-          trump: round.trumpSuit(),
-        );
-        print("*** ddPlays: $ddPlays");
-      }
+      // if (!round.isOver()) {
+      //   final ddPlays = doubleDummyResultForAllCards(
+      //     hands: [for (final p in round.players) p.hand],
+      //     currentTrick: round.currentTrick,
+      //     trump: round.trumpSuit(),
+      //   );
+      //   print("*** ddPlays: $ddPlays");
+      // }
     }
 
   }
@@ -1401,7 +1401,7 @@ class EndOfRoundDialog extends StatelessWidget {
             Text("IMPs: ${plusPrefixIfPositive(impsForScoreDifference(scoreDiff))}")
         ),
       ]),
-      if (onShowDetails != null) makeRow([
+      if (onShowDetails != null && !(round.isPassedOut() && duplicateRound.isPassedOut())) makeRow([
         TextButton(
           onPressed: onShowDetails,
           child: const Text("Show details", style: TextStyle(fontSize: 12)),
@@ -1540,13 +1540,80 @@ class RoundDetailsDialog extends StatefulWidget {
   State<RoundDetailsDialog> createState() => _RoundDetailsDialogState();
 }
 
+class BadDoubleDummyPlay {
+  final PlayingCard actualCard;
+  final List<PlayingCard> bestCards;
+  final int tricksCost;
+
+  BadDoubleDummyPlay(this.actualCard, this.bestCards, this.tricksCost);
+}
+
 class _RoundDetailsDialogState extends State<RoundDetailsDialog> {
   bool showDuplicate = false;
   int selectedTabIndex = 0;
   int trickIndex = 0;
+  // A list of "mistakes" for each player for the currently displayed trick,
+  // as reported by the double-dummy solver. This doesn't necessarily mean that
+  // the play was game-theoretically wrong, only that if the player had known
+  // where all the cards were, they should have played differently.
+  List<BadDoubleDummyPlay?> ddMistakes = [null, null, null, null];
 
   BridgeRound get selectedRound =>
       showDuplicate ? widget.duplicateRound : widget.round;
+
+  @override
+  void initState() {
+    super.initState();
+    updateBetterCardPlays();
+  }
+
+  void updateBetterCardPlays() {
+    if (selectedRound.isPassedOut()) {
+      return;
+    }
+    final displayedTrick = selectedRound.previousTricks[trickIndex];
+    for (int ci = 0; ci < 4; ci++) {
+      int playerIndex = (displayedTrick.leader + ci) % 4;
+      final ddEvaluations = doubleDummyResultForPreviousPointInRound(
+        round: selectedRound,
+        completedTricks: trickIndex,
+        cardsInCurrentTrick: ci,
+      );
+      if (ddEvaluations == null) {
+        ddMistakes[playerIndex] = null;
+      }
+      else {
+        final actualCardPlayed = displayedTrick.cards[ci];
+        int bestValue = ddEvaluations.entries.first.value;
+        int diff = bestValue - ddEvaluations[actualCardPlayed]!;
+        if (ddEvaluations[actualCardPlayed]! < bestValue) {
+          final bestPlays = ddEvaluations.keys
+              .where((card) => ddEvaluations[card] == bestValue)
+              .toList();
+          ddMistakes[playerIndex] = BadDoubleDummyPlay(actualCardPlayed, bestPlays, diff);
+        }
+        else {
+          ddMistakes[playerIndex] = null;
+        }
+      }
+    }
+  }
+
+  void incrementTrickIndex() {
+    if (trickIndex >= 12) {
+      return;
+    }
+    trickIndex += 1;
+    updateBetterCardPlays();
+  }
+
+  void decrementTrickIndex() {
+    if (trickIndex <= 0) {
+      return;
+    }
+    trickIndex -= 1;
+    updateBetterCardPlays();
+  }
 
   Widget biddingTab() {
     Widget headerCell(String msg) => paddingAll(
@@ -1571,6 +1638,9 @@ class _RoundDetailsDialogState extends State<RoundDetailsDialog> {
       final cardIndex = (playerIndex - trick.leader) % 4;
       final card = trick.cards[cardIndex];
       final isWinner = playerIndex == trick.winner;
+      const cardHeight = 72.0;
+      const cardWidth = cardHeight * defaultCardAspectRatio;
+      final mistake = ddMistakes[playerIndex];
       return Container(
           decoration: BoxDecoration(
             border: Border.all(
@@ -1578,8 +1648,22 @@ class _RoundDetailsDialogState extends State<RoundDetailsDialog> {
                 width: 2.5),
             borderRadius: BorderRadius.circular(5),
           ),
-          child: Image.asset("assets/cards/solid/${card.toString()}.webp",
-              height: 72));
+          child: Stack(children: [
+            Image.asset("assets/cards/solid/${card.toString()}.webp", height: 72),
+            if (mistake != null)
+              SizedBox(
+                  height: cardHeight,
+                  width: cardWidth,
+                  child: Center(
+                    child: Container(
+                      width: cardWidth,
+                      color: Colors.yellow,
+                      child: SizedBox(width: cardWidth, height: 32, child: Center(child: Text(
+                        "-${mistake.tricksCost} ${mistake.tricksCost == 1 ? 'trick' : 'tricks'}\nBest: ${mistake.bestCards.first.symbolString()}",
+                        style: TextStyle(fontSize: 10)))))
+                  ),
+              ),
+          ]));
     }
 
     // Cross layout matching the table: N top, W left, E right, S bottom.
@@ -1604,7 +1688,7 @@ class _RoundDetailsDialogState extends State<RoundDetailsDialog> {
         IconButton(
           icon: const Icon(Icons.chevron_left),
           onPressed: trickIndex > 0
-              ? () => setState(() => trickIndex -= 1)
+              ? () => setState(decrementTrickIndex)
               : null,
         ),
         Text("Trick ${trickIndex + 1} of ${tricks.length}",
@@ -1612,7 +1696,7 @@ class _RoundDetailsDialogState extends State<RoundDetailsDialog> {
         IconButton(
           icon: const Icon(Icons.chevron_right),
           onPressed: trickIndex < tricks.length - 1
-              ? () => setState(() => trickIndex += 1)
+              ? () => setState(incrementTrickIndex)
               : null,
         ),
       ]),
@@ -1649,6 +1733,7 @@ class _RoundDetailsDialogState extends State<RoundDetailsDialog> {
                           selected: {showDuplicate},
                           onSelectionChanged: (selection) => setState(() {
                             showDuplicate = selection.first;
+                            updateBetterCardPlays();
                             // Intentionally keep the trick index where it was.
                           }),
                         )),

--- a/lib/bridge_ui.dart
+++ b/lib/bridge_ui.dart
@@ -336,7 +336,17 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
         _runDuplicateRound();
       }
       _updateStatsIfMatchOrRoundOver();
+      // Testing
+      if (!round.isOver()) {
+        final ddPlays = doubleDummyResultForAllCards(
+          hands: [for (final p in round.players) p.hand],
+          currentTrick: round.currentTrick,
+          trump: round.trumpSuit(),
+        );
+        print("*** ddPlays: $ddPlays");
+      }
     }
+
   }
 
   void _clearMoods() {

--- a/lib/bridge_ui.dart
+++ b/lib/bridge_ui.dart
@@ -1569,11 +1569,12 @@ class _RoundDetailsDialogState extends State<RoundDetailsDialog> {
 
   void updateBetterCardPlays() {
     if (selectedRound.isPassedOut()) {
+      ddMistakes = [null, null, null, null];
       return;
     }
     final displayedTrick = selectedRound.previousTricks[trickIndex];
-    for (int ci = 0; ci < 4; ci++) {
-      int playerIndex = (displayedTrick.leader + ci) % 4;
+    for (int ci = 0; ci < selectedRound.numberOfPlayers; ci++) {
+      int playerIndex = (displayedTrick.leader + ci) % selectedRound.numberOfPlayers;
       final ddEvaluations = doubleDummyResultForPreviousPointInRound(
         round: selectedRound,
         completedTricks: trickIndex,
@@ -1600,7 +1601,7 @@ class _RoundDetailsDialogState extends State<RoundDetailsDialog> {
   }
 
   void incrementTrickIndex() {
-    if (trickIndex >= 12) {
+    if (trickIndex >= selectedRound.previousTricks.length - 1) {
       return;
     }
     trickIndex += 1;
@@ -1635,7 +1636,7 @@ class _RoundDetailsDialogState extends State<RoundDetailsDialog> {
     final trick = tricks[trickIndex];
 
     Widget seatCard(int playerIndex) {
-      final cardIndex = (playerIndex - trick.leader) % 4;
+      final cardIndex = (playerIndex - trick.leader) % selectedRound.numberOfPlayers;
       final card = trick.cards[cardIndex];
       final isWinner = playerIndex == trick.winner;
       const cardHeight = 72.0;
@@ -1649,7 +1650,7 @@ class _RoundDetailsDialogState extends State<RoundDetailsDialog> {
             borderRadius: BorderRadius.circular(5),
           ),
           child: Stack(children: [
-            Image.asset("assets/cards/solid/${card.toString()}.webp", height: 72),
+            Image.asset("assets/cards/solid/${card.toString()}.webp", height: cardHeight),
             if (mistake != null)
               SizedBox(
                   height: cardHeight,
@@ -1660,7 +1661,7 @@ class _RoundDetailsDialogState extends State<RoundDetailsDialog> {
                       color: Colors.yellow,
                       child: SizedBox(width: cardWidth, height: 32, child: Center(child: Text(
                         "-${mistake.tricksCost} ${mistake.tricksCost == 1 ? 'trick' : 'tricks'}\nBest: ${mistake.bestCards.first.symbolString()}",
-                        style: TextStyle(fontSize: 10)))))
+                        style: const TextStyle(fontSize: 10)))))
                   ),
               ),
           ]));

--- a/lib/bridge_ui.dart
+++ b/lib/bridge_ui.dart
@@ -1656,12 +1656,12 @@ class _RoundDetailsDialogState extends State<RoundDetailsDialog> {
                   height: cardHeight,
                   width: cardWidth,
                   child: Center(
-                    child: Container(
+                    child: Opacity(opacity: 0.9, child: Container(
                       width: cardWidth,
                       color: Colors.yellow,
                       child: SizedBox(width: cardWidth, height: 32, child: Center(child: Text(
                         "-${mistake.tricksCost} ${mistake.tricksCost == 1 ? 'trick' : 'tricks'}\nBest: ${mistake.bestCards.first.symbolString()}",
-                        style: const TextStyle(fontSize: 10)))))
+                        style: const TextStyle(fontSize: 10))))))
                   ),
               ),
           ]));

--- a/lib/bridge_ui.dart
+++ b/lib/bridge_ui.dart
@@ -336,15 +336,6 @@ class BridgeMatchState extends State<BridgeMatchDisplay> {
         _runDuplicateRound();
       }
       _updateStatsIfMatchOrRoundOver();
-      // Testing
-      // if (!round.isOver()) {
-      //   final ddPlays = doubleDummyResultForAllCards(
-      //     hands: [for (final p in round.players) p.hand],
-      //     currentTrick: round.currentTrick,
-      //     trump: round.trumpSuit(),
-      //   );
-      //   print("*** ddPlays: $ddPlays");
-      // }
     }
 
   }

--- a/test/bridge/double_dummy_review_test.dart
+++ b/test/bridge/double_dummy_review_test.dart
@@ -1,0 +1,384 @@
+// Tests for the double-dummy "review the play" support: reconstructing the
+// position at an earlier point in a completed round, and scoring every legal
+// play from that position.
+//
+// The tests that need the native DDS backend are skipped when it isn't
+// loaded; run them with `DDS_LIB=native/libdds.dylib flutter test`
+// (see cpp/build_libdds.sh).
+import "dart:math";
+
+import "package:cards_with_cats/bridge/bridge.dart";
+import "package:cards_with_cats/bridge/bridge_ai.dart";
+import "package:cards_with_cats/bridge/dd_solver.dart";
+import "package:cards_with_cats/bridge/dds_ffi.dart";
+import "package:cards_with_cats/cards/card.dart";
+import "package:cards_with_cats/cards/trick.dart";
+import "package:flutter_test/flutter_test.dart";
+
+const c = PlayingCard.cardsFromString;
+
+final ddsAvailable = DdsBackend.instance != null;
+const ddsSkipReason =
+    "Native DDS backend not loaded; set DDS_LIB (see cpp/build_libdds.sh)";
+
+/// Bids to a contract and then plays random legal cards until the round ends.
+BridgeRound playedOutRound(Random rng, {Suit? trump = Suit.spades}) {
+  final round = BridgeRound.deal(rng.nextInt(4), rng);
+  round.addBid(
+      PlayerBid(round.currentBidder(), BidAction.contract(3, trump)));
+  for (int i = 0; i < 3; i++) {
+    round.addBid(PlayerBid(round.currentBidder(), BidAction.pass()));
+  }
+  while (!round.isOver()) {
+    final legal = round.legalPlaysForCurrentPlayer();
+    round.playCard(legal[rng.nextInt(legal.length)]);
+  }
+  return round;
+}
+
+/// A random position with [cardsPerHand] cards each and [cardsInTrick] cards
+/// already played to the trick in progress, in the layout the solvers expect:
+/// players who have already played hold one card fewer.
+({List<List<PlayingCard>> hands, TrickInProgress trick}) randomPosition(
+    Random rng, int cardsPerHand, int cardsInTrick) {
+  final deck = List.of(standardDeckCards())..shuffle(rng);
+  final hands = List.generate(
+      4, (p) => deck.sublist(p * cardsPerHand, (p + 1) * cardsPerHand));
+  final trick = TrickInProgress(rng.nextInt(4));
+  for (int i = 0; i < cardsInTrick; i++) {
+    final player = (trick.leader + i) % 4;
+    final legal = legalPlays(hands[player], trick);
+    final card = legal[rng.nextInt(legal.length)];
+    hands[player].remove(card);
+    trick.cards.add(card);
+  }
+  return (hands: hands, trick: trick);
+}
+
+/// Tricks taken by the side on play if it plays [card], computed with the
+/// pure-Dart solver. Deliberately independent of the single-call DDS path:
+/// it removes the card, resolves the trick if the card completes it, and
+/// solves the resulting position.
+int referenceTricksForSideOnPlay(List<List<PlayingCard>> hands, Suit? trump,
+    TrickInProgress trick, PlayingCard card) {
+  final mover = (trick.leader + trick.cards.length) % 4;
+  final totalTricks = hands[mover].length;
+  final handsAfter = [...hands];
+  handsAfter[mover] = [...hands[mover]]..remove(card);
+  final trickCards = [...trick.cards, card];
+
+  final int nsTricks;
+  if (trickCards.length == 4) {
+    final winner =
+        TrickInProgress(trick.leader, trickCards).finish(trump: trump).winner;
+    nsTricks = DDSolver.fromHands(handsAfter, trump, winner).solve() +
+        (winner % 2 == 0 ? 1 : 0);
+  } else {
+    final solver = DDSolver.fromHands(handsAfter, trump, trick.leader);
+    for (final tc in trickCards) {
+      solver.addTrickCard(tc);
+    }
+    nsTricks = solver.solve();
+  }
+  return mover % 2 == 0 ? nsTricks : totalTricks - nsTricks;
+}
+
+void main() {
+  group("roundStateAtPointInPlay", () {
+    test("reconstructs every position in a completed round", () {
+      final leadersSeen = <int>{};
+      for (int seed = 1; seed <= 5; seed++) {
+        final round = playedOutRound(Random(seed));
+        for (int ti = 0; ti < round.previousTricks.length; ti++) {
+          final trick = round.previousTricks[ti];
+          leadersSeen.add(trick.leader);
+          // Every card from this trick onwards is either still in a hand or
+          // already played to the trick in progress, and appears exactly once.
+          final unplayed = <PlayingCard>{};
+          for (int later = ti; later < round.previousTricks.length; later++) {
+            unplayed.addAll(round.previousTricks[later].cards);
+          }
+          for (int ci = 0; ci < 4; ci++) {
+            final state = roundStateAtPointInPlay(
+                round: round, completedTricks: ti, cardsInCurrentTrick: ci);
+            final reason = "seed $seed trick $ti leader ${trick.leader} ci $ci";
+
+            expect(state.currentTrick.leader, trick.leader, reason: reason);
+            expect(state.currentTrick.cards, trick.cards.sublist(0, ci),
+                reason: reason);
+
+            // Players who have already played to this trick hold one card
+            // fewer than those who have not.
+            final cardsRemaining = round.previousTricks.length - ti;
+            for (int p = 0; p < 4; p++) {
+              final hasPlayed = (p - trick.leader) % 4 < ci;
+              expect(state.hands[p].length,
+                  hasPlayed ? cardsRemaining - 1 : cardsRemaining,
+                  reason: "$reason player $p");
+            }
+
+            final allHeld = [for (final h in state.hands) ...h];
+            expect(allHeld.toSet().length, allHeld.length,
+                reason: "$reason: a card is held twice");
+            expect({...allHeld, ...state.currentTrick.cards}, unplayed,
+                reason: reason);
+
+            // The player on play must hold the card they actually played.
+            final mover = (trick.leader + ci) % 4;
+            expect(state.hands[mover], contains(trick.cards[ci]),
+                reason: reason);
+          }
+        }
+      }
+      // The bug this guards against only showed up for tricks not led by
+      // player 0, so make sure the sample actually covers those.
+      expect(leadersSeen, containsAll([0, 1, 2, 3]));
+    });
+
+    test("removes cards in the trick in progress from the player who played "
+        "them, not from player 0", () {
+      // Regression: the removal used `% currentTrick.cards.length` instead of
+      // `% 4`, so for a trick not led by player 0 the cards were removed from
+      // the wrong hand (usually a no-op), leaving a player holding a card that
+      // was also sitting in the trick.
+      final round = playedOutRound(Random(11));
+      final nonZeroLeaderTricks = [
+        for (int ti = 0; ti < round.previousTricks.length; ti++)
+          if (round.previousTricks[ti].leader != 0) ti
+      ];
+      expect(nonZeroLeaderTricks, isNotEmpty);
+      for (final ti in nonZeroLeaderTricks) {
+        for (int ci = 1; ci < 4; ci++) {
+          final state = roundStateAtPointInPlay(
+              round: round, completedTricks: ti, cardsInCurrentTrick: ci);
+          for (final played in state.currentTrick.cards) {
+            for (int p = 0; p < 4; p++) {
+              expect(state.hands[p], isNot(contains(played)),
+                  reason: "trick $ti ci $ci: $played still held by player $p");
+            }
+          }
+        }
+      }
+    });
+
+    test("rejects rounds that are not over and out-of-range indexes", () {
+      final inProgress = BridgeRound.deal(0, Random(3));
+      expect(
+          () => roundStateAtPointInPlay(
+              round: inProgress, completedTricks: 0, cardsInCurrentTrick: 0),
+          throwsA(isA<Exception>()));
+
+      final round = playedOutRound(Random(3));
+      expect(
+          () => roundStateAtPointInPlay(
+              round: round, completedTricks: 13, cardsInCurrentTrick: 0),
+          throwsRangeError);
+      expect(
+          () => roundStateAtPointInPlay(
+              round: round, completedTricks: -1, cardsInCurrentTrick: 0),
+          throwsRangeError);
+      expect(
+          () => roundStateAtPointInPlay(
+              round: round, completedTricks: 0, cardsInCurrentTrick: 4),
+          throwsRangeError);
+    });
+  });
+
+  group("DdsBackend.solveAllCards", () {
+    test("credits the card that wins the trick in progress", () {
+      // Notrump. Player 0 led the king of spades and players 1 and 2 have
+      // followed, so only their remaining cards are in the hands. Player 3
+      // (E/W) is on play: the ace wins this trick and leaves the two of
+      // spades good for the next one, while the two of spades loses both.
+      final hands = [
+        c("2C"), // player 0, N/S, already played the king of spades
+        c("3C"), // player 1, E/W
+        c("4C"), // player 2, N/S
+        c("AS 2S"), // player 3, E/W, on play
+      ];
+      final result =
+          DdsBackend.instance!.solveAllCards(hands, null, 0, c("KS 3S 4S"));
+      expect(result, {c("AS")[0]: 2, c("2S")[0]: 0});
+    });
+
+    test("scores a lead from the leading side's perspective", () {
+      // The same deal one card earlier, with player 0 (N/S) on lead. Leading
+      // the king into player 3's ace concedes both tricks; leading the club
+      // instead wins that trick for player 2 and holds E/W to one.
+      final hands = [
+        c("KS 2C"), // player 0, N/S, on lead
+        c("3S 3C"), // player 1, E/W
+        c("4S 4C"), // player 2, N/S
+        c("AS 2S"), // player 3, E/W
+      ];
+      final result =
+          DdsBackend.instance!.solveAllCards(hands, null, 0, const []);
+      // Counted for N/S, the side on play, not for a fixed side.
+      expect(result, {c("2C")[0]: 1, c("KS")[0]: 0});
+    });
+
+    test("covers exactly the legal plays", () {
+      final rng = Random(29);
+      for (int cardsInTrick = 0; cardsInTrick < 4; cardsInTrick++) {
+        for (int i = 0; i < 15; i++) {
+          final pos = randomPosition(rng, 5, cardsInTrick);
+          final mover = (pos.trick.leader + cardsInTrick) % 4;
+          final trump = [null, Suit.spades, Suit.hearts][i % 3];
+          final result = DdsBackend.instance!
+              .solveAllCards(pos.hands, trump, pos.trick.leader, pos.trick.cards);
+          expect(result, isNotNull);
+          expect(result!.keys.toSet(),
+              legalPlays(pos.hands[mover], pos.trick).toSet(),
+              reason: "trump $trump, $cardsInTrick cards in trick");
+        }
+      }
+    });
+
+    test("agrees with the pure-Dart solver on random endings", () {
+      final rng = Random(31);
+      int checked = 0;
+      for (int cardsInTrick = 0; cardsInTrick < 4; cardsInTrick++) {
+        for (int i = 0; i < 8; i++) {
+          final pos = randomPosition(rng, 4, cardsInTrick);
+          final trump = [null, Suit.spades, Suit.diamonds][i % 3];
+          final result = DdsBackend.instance!
+              .solveAllCards(pos.hands, trump, pos.trick.leader, pos.trick.cards);
+          expect(result, isNotNull);
+          for (final entry in result!.entries) {
+            expect(
+                entry.value,
+                referenceTricksForSideOnPlay(
+                    pos.hands, trump, pos.trick, entry.key),
+                reason: "card ${entry.key}, trump $trump, "
+                    "leader ${pos.trick.leader}, trick ${pos.trick.cards}");
+            checked++;
+          }
+        }
+      }
+      expect(checked, greaterThan(50));
+    });
+
+    test("rejects a complete trick, which DDS cannot represent", () {
+      final hands = [c("KS"), c("3S"), c("4S"), c("AS")];
+      expect(
+          () => DdsBackend.instance!
+              .solveAllCards(hands, null, 0, c("KS 3S 4S AS")),
+          throwsArgumentError);
+    });
+  }, skip: ddsAvailable ? null : ddsSkipReason);
+
+  group("doubleDummyResultForAllCards", () {
+    test("orders cards from most tricks to fewest", () {
+      final rng = Random(37);
+      for (int cardsInTrick = 0; cardsInTrick < 4; cardsInTrick++) {
+        for (int i = 0; i < 8; i++) {
+          final pos = randomPosition(rng, 5, cardsInTrick);
+          final trump = i.isEven ? null : Suit.clubs;
+          final result = doubleDummyResultForAllCards(
+              currentTrick: pos.trick, hands: pos.hands, trump: trump);
+          expect(result, isNotNull);
+          final values = result!.values.toList();
+          expect(values, orderedEquals([...values]..sort((a, b) => b - a)));
+          expect(values.first, values.reduce(max));
+        }
+      }
+    });
+
+    test("agrees with the pure-Dart solver for both sides", () {
+      final rng = Random(41);
+      final moversSeen = <int>{};
+      for (int cardsInTrick = 0; cardsInTrick < 4; cardsInTrick++) {
+        for (int i = 0; i < 6; i++) {
+          final pos = randomPosition(rng, 4, cardsInTrick);
+          final trump = i.isEven ? null : Suit.hearts;
+          moversSeen.add((pos.trick.leader + cardsInTrick) % 4);
+          final result = doubleDummyResultForAllCards(
+              currentTrick: pos.trick, hands: pos.hands, trump: trump);
+          expect(result, isNotNull);
+          for (final entry in result!.entries) {
+            expect(
+                entry.value,
+                referenceTricksForSideOnPlay(
+                    pos.hands, trump, pos.trick, entry.key),
+                reason: "card ${entry.key}, trump $trump");
+          }
+        }
+      }
+      // Both N/S (even) and E/W (odd) players must be exercised, since their
+      // scores come from opposite sides of the solver's convention.
+      expect(moversSeen, containsAll([0, 1, 2, 3]));
+    });
+  }, skip: ddsAvailable ? null : ddsSkipReason);
+
+  group("doubleDummyResultForPreviousPointInRound", () {
+    test("evaluates every seat in every trick", () {
+      // Regression: only the seat on lead (ci == 0) used to produce a result;
+      // the other three returned null because the reconstructed deal was
+      // malformed and DDS rejected it.
+      final round = playedOutRound(Random(13), trump: Suit.hearts);
+      for (int ti = 0; ti < round.previousTricks.length; ti++) {
+        final trick = round.previousTricks[ti];
+        for (int ci = 0; ci < 4; ci++) {
+          final result = doubleDummyResultForPreviousPointInRound(
+              round: round, completedTricks: ti, cardsInCurrentTrick: ci);
+          final reason = "trick $ti leader ${trick.leader} ci $ci";
+          expect(result, isNotNull, reason: reason);
+          // The card actually played is always one of the evaluated options.
+          expect(result!.keys, contains(trick.cards[ci]), reason: reason);
+          final state = roundStateAtPointInPlay(
+              round: round, completedTricks: ti, cardsInCurrentTrick: ci);
+          final mover = (trick.leader + ci) % 4;
+          expect(result.keys.toSet(),
+              legalPlays(state.hands[mover], state.currentTrick).toSet(),
+              reason: reason);
+          // Tricks available to the side on play, so values are in range.
+          for (final v in result.values) {
+            expect(v, inInclusiveRange(0, state.hands[mover].length),
+                reason: reason);
+          }
+        }
+      }
+    });
+
+    test("matches evaluating the reconstructed position directly", () {
+      for (int seed = 1; seed <= 3; seed++) {
+        final round = playedOutRound(Random(seed), trump: null);
+        for (final ti in [0, 4, 8, 12]) {
+          for (int ci = 0; ci < 4; ci++) {
+            final state = roundStateAtPointInPlay(
+                round: round, completedTricks: ti, cardsInCurrentTrick: ci);
+            final expected = doubleDummyResultForAllCards(
+                currentTrick: state.currentTrick,
+                hands: state.hands,
+                trump: round.trumpSuit());
+            final actual = doubleDummyResultForPreviousPointInRound(
+                round: round, completedTricks: ti, cardsInCurrentTrick: ci);
+            expect(actual, expected, reason: "seed $seed trick $ti ci $ci");
+          }
+        }
+      }
+    });
+
+    test("agrees with the pure-Dart solver in the endgame", () {
+      // Late tricks leave few enough cards for the pure-Dart solver to act as
+      // an independent oracle over the whole reconstruct-and-score path.
+      final round = playedOutRound(Random(23), trump: Suit.clubs);
+      for (final ti in [9, 10, 11]) {
+        for (int ci = 0; ci < 4; ci++) {
+          final state = roundStateAtPointInPlay(
+              round: round, completedTricks: ti, cardsInCurrentTrick: ci);
+          final result = doubleDummyResultForPreviousPointInRound(
+              round: round, completedTricks: ti, cardsInCurrentTrick: ci);
+          expect(result, isNotNull);
+          for (final entry in result!.entries) {
+            expect(
+                entry.value,
+                referenceTricksForSideOnPlay(state.hands, round.trumpSuit(),
+                    state.currentTrick, entry.key),
+                reason: "trick $ti ci $ci card ${entry.key}");
+          }
+        }
+      }
+    });
+  }, skip: ddsAvailable ? null : ddsSkipReason);
+}


### PR DESCRIPTION
When reviewing play for either the player's round or the duplicate round, highlight cards that were "mistakes" according to the double-dummy solver. (Which doesn't necessarily mean it was a bad decision, it may have been "correct" given the limited information the player had at the time).