### PR TITLE
Preemptive raise to game over an overcall; strong raises all cue-bid

### DIFF
--- a/lib/bridge/sayc/README.md
+++ b/lib/bridge/sayc/README.md
@@ -360,11 +360,11 @@ down as gaps get fixed; a jump up means a regression.
 
 | Run | Result |
 | --- | --- |
-| seed 1, 3000 deals (test set) | 653 findings, 0 hard failures |
-| seed 42, 4000 deals (dev) | 888 findings, 0 hard failures |
+| seed 1, 3000 deals (test set) | 638 findings, 0 hard failures |
+| seed 42, 4000 deals (dev) | 873 findings, 0 hard failures |
 | chaos 0.15, 5000 deals | 0 hard failures |
 
-Seed 1 findings by category: fallback-used 433, missed-game 143,
+Seed 1 findings by category: fallback-used 417, missed-game 144,
 silly-strain 50, missed-slam 25, thin-game 1, no-rule-matched 1.
 Fallback-used is monitoring, not failure. The missed-game lint excuses
 stops below game when an opponent-bid suit is unstopped, there is no

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -4411,6 +4411,28 @@ List<SaycRule> interferenceResponseRules(
   final cheapest = cheapestLevel(suit, overcall);
 
   final raiseRules = <SaycRule>[];
+  if (isMajor && cheapest <= 4) {
+    // Preemptive raise to game: bid to the level of the fit at once. The
+    // uncontested 5+ trump raise applies, and in competition four trumps
+    // with a singleton or void qualify too; strong raises (13+) go through
+    // the cue bid instead, so this covers everything below that.
+    bool shortSuit(HandAnalysis h) =>
+        Suit.values.any((s) => s != suit && h.count(s) <= 1);
+    raiseRules.add(SaycRule(
+      BidAction.contract(4, suit),
+      BidMeaning(
+        description:
+            "Preemptive raise to game: 5+ $name (or 4 with a singleton or void), 6-12 points",
+        totalPoints: const Range(low: 6, high: 12),
+        suitLengths: {suit: const Range(low: 4)},
+      ),
+      ignoreInfo: true,
+      require: (h) =>
+          h.totalPoints >= 6 &&
+          h.totalPoints <= 12 &&
+          (h.count(suit) >= 5 || (h.count(suit) == 4 && shortSuit(h))),
+    ));
+  }
   if (cheapest == 2) {
     raiseRules.add(SaycRule(
       BidAction.contract(2, suit),
@@ -4447,17 +4469,7 @@ List<SaycRule> interferenceResponseRules(
       ),
     ));
   }
-  if (isMajor) {
-    raiseRules.add(SaycRule(
-      BidAction.contract(4, suit),
-      BidMeaning(
-        description: "Raise to game: 4+ $name",
-        totalPoints: const Range(low: 13),
-        suitLengths: {suit: const Range(low: 4)},
-      ),
-    ));
-  }
-  // Game-forcing raise without a direct game bid: cue-bid their suit. For
+  // Game-forcing raise: cue-bid their suit (any number of trumps). For
   // a major this is the normal route with 3-card support (the 5-3 fit is
   // preferred to 3NT) and ranks with the raises; for a minor it is the hand
   // with support but no stopper (with a stopper 3NT is bid directly) and
@@ -4482,12 +4494,12 @@ List<SaycRule> interferenceResponseRules(
               (isMajor || !h.hasStopper(theirSuit)),
         );
   if (isMajor && cueRule != null) raiseRules.add(cueRule);
-  // A jump overcall that leaves no cue below game (e.g. 1H 3S): the
-  // game-forcing raise bids the game itself. A major with 3+ support goes
-  // straight to four; a minor with 4+ support and no stopper bids four of
-  // the minor, which opener raises with extras (see
+  // A jump overcall that leaves no cue below game (e.g. 1H 3S or 1H 3C):
+  // the game-forcing raise bids the game itself. A major with 3+ support
+  // goes straight to four; a minor with 4+ support and no stopper bids four
+  // of the minor, which opener raises with extras (see
   // [jumpOvercallRaiseRebidRules]).
-  final noCueGameRaise = cueRule != null || cheapest != 4
+  final noCueGameRaise = cueRule != null || cheapest > 4
       ? null
       : SaycRule(
           BidAction.contract(4, suit),

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1334,8 +1334,9 @@ void main() {
           "2H");
       expect(openingBid("K32", "K32", "KQ32", "432", history: ["1H", "2C"]),
           "3H");
+      // A 13-count with four trumps cue-bids; the direct 4H is preemptive.
       expect(openingBid("32", "K432", "AK32", "K32", history: ["1H", "1S"]),
-          "4H");
+          "2S");
     });
 
     test("three-level free bids with 12+", () {
@@ -1861,9 +1862,10 @@ void main() {
           "3S");
       expect(openingBid("T62", "K95", "AT87", "AK6", history: ["1S", "2H"]),
           "3H");
-      // Four trumps still raise to game directly.
+      // Four trumps with game values also cue-bid; the direct 4H is the
+      // preemptive raise.
       expect(openingBid("T6", "K952", "AT87", "AK6", history: ["1H", "2S"]),
-          "4H");
+          "3S");
       // Minor opening: cue with support and no stopper, 3NT with one.
       expect(openingBid("T62", "K9", "AT875", "AK6", history: ["1D", "2S"]),
           "3S");
@@ -1873,6 +1875,37 @@ void main() {
       // deal 429, seed 1).
       expect(openingBid("J8532", "Q2", "AKQ6", "63", history: ["1D", "1H"]),
           "1S");
+    });
+
+    test("preemptive raise to game over an overcall", () {
+      // Five trumps, or four with a singleton or void, 6-12 points.
+      expect(openingBid("T6", "K9532", "A873", "43", history: ["1H", "1S"]),
+          "4H");
+      expect(openingBid("T6", "K952", "AT8732", "4", history: ["1H", "1S"]),
+          "4H");
+      expect(openingBid("T6", "K952", "AT8732", "4", history: ["1H", "2S"]),
+          "4H");
+      // Four trumps without shortness make the ordinary raise.
+      expect(openingBid("T62", "K952", "A873", "43", history: ["1H", "1S"]),
+          "2H");
+      // Strong hands cue-bid instead, whatever the shape.
+      expect(openingBid("6", "K952", "AT873", "AK4", history: ["1H", "1S"]),
+          "2S");
+      // Too weak even for a preemptive raise.
+      expect(openingBid("T6", "T9532", "9873", "43", history: ["1H", "1S"]),
+          "Pass");
+    });
+
+    test("game raise with support when a lower-suit jump overcall takes the cue",
+        () {
+      // Over 1H 3C the cue would be 4C: bid the game directly.
+      expect(openingBid("T62", "K95", "AT87", "AK6", history: ["1H", "3C"]),
+          "4H");
+      expect(openingBid("AK6", "K9", "AT875", "T62", history: ["1D", "3C"]),
+          "4D");
+      expect(openingBid("43", "K7", "AQJ73", "KQ72",
+              history: ["1D", "3C", "4D", "pass"]),
+          "5D");
     });
 
     test("game raise with 3-card support when the jump overcall takes the cue",


### PR DESCRIPTION
After overcall of partner's major opening:
- Raise to 4 is semi-preemptive with 6-12 points and either 5+ trumps or 4 with a singleton or void
- Cuebid is game-forcing with 3+ trumps