### PR TITLE
Penalty double of a 1NT opening

### DIFF
--- a/lib/bridge/sayc/README.md
+++ b/lib/bridge/sayc/README.md
@@ -360,11 +360,11 @@ down as gaps get fixed; a jump up means a regression.
 
 | Run | Result |
 | --- | --- |
-| seed 1, 3000 deals (test set) | 632 findings, 0 hard failures |
-| seed 42, 4000 deals (dev) | 858 findings, 0 hard failures |
+| seed 1, 3000 deals (test set) | 634 findings, 0 hard failures |
+| seed 42, 4000 deals (dev) | 860 findings, 0 hard failures |
 | chaos 0.15, 5000 deals | 0 hard failures |
 
-Seed 1 findings by category: fallback-used 417, missed-game 144,
+Seed 1 findings by category: fallback-used 420, missed-game 143,
 silly-strain 50, missed-slam 19, thin-game 1, no-rule-matched 1.
 Fallback-used is monitoring, not failure. The missed-game lint excuses
 stops below game when an opponent-bid suit is unstopped, there is no

--- a/lib/bridge/sayc/sayc_bidding.dart
+++ b/lib/bridge/sayc/sayc_bidding.dart
@@ -4450,6 +4450,15 @@ List<SaycRule> directActionRules(ContractBid opening,
     // 6-card suit; no conventional defenses (Cappelletti/DONT) yet.
     final rules = <SaycRule>[];
     if (opening.count == 1) {
+      // A double of 1NT is penalty-oriented: a hand at least as good as
+      // their opening (partner pulls only when weak with a long suit).
+      rules.add(SaycRule(
+        BidAction.double(),
+        BidMeaning(
+          description: "Penalty double of 1NT: 15+ HCP",
+          hcp: const Range(low: 15),
+        ),
+      ));
       for (final suit in Suit.values) {
         rules.add(SaycRule(
           BidAction.contract(2, suit),
@@ -4894,6 +4903,56 @@ List<SaycRule>? rhoDoubleRules(BidAction opening) {
 /// when RHO passed the advance is forced. When RHO redoubled, all passes are
 /// suppressed: even a worthless hand runs to a suit rather than offering to
 /// defend a redoubled contract.
+/// Advancing partner's penalty double of a 1NT opening. The double shows a
+/// hand that expects to beat 1NT, so passing to defend is the default; only
+/// a weak hand with a long suit pulls (it offers no defensive tricks and a
+/// suit partscore rates better than defending with nothing). If the
+/// opener's side runs to a suit ([runout] non-null), a double of that is
+/// penalty too.
+List<SaycRule> oneNtDoubleAdvanceRules(ContractBid? runout) {
+  if (runout?.trump != null) {
+    final theirSuit = runout!.trump!;
+    return [
+      SaycRule(
+        BidAction.double(),
+        BidMeaning(
+          description:
+              "Penalty double of the runout: 4+ ${_suitNames[theirSuit]}, 8+ HCP",
+          hcp: const Range(low: 8),
+          suitLengths: {theirSuit: const Range(low: 4)},
+        ),
+        ignoreInfo: true,
+        require: (h) => h.hcp >= 8 && h.count(theirSuit) >= 4,
+      ),
+      SaycRule(
+        BidAction.pass(),
+        BidMeaning(description: "Nothing to say over the runout"),
+      ),
+    ];
+  }
+  return [
+    for (final suit in Suit.values)
+      SaycRule(
+        BidAction.contract(2, suit),
+        BidMeaning(
+          description:
+              "Pulling the penalty double: weak with 5+ ${_suitNames[suit]}",
+          hcp: const Range(high: 4),
+          suitLengths: {suit: const Range(low: 5)},
+        ),
+        ignoreInfo: true,
+        require: (h) =>
+            h.hcp <= 4 &&
+            h.count(suit) >= 5 &&
+            bestSuit(h, Suit.values.where((s) => h.count(s) >= 5)) == suit,
+      ),
+    SaycRule(
+      BidAction.pass(),
+      BidMeaning(description: "Leaving the penalty double in"),
+    ),
+  ];
+}
+
 List<SaycRule> advanceDoubleRules(
     ContractBid theirOpening, ContractBid over, bool forced,
     {bool redoubled = false}) {
@@ -6904,6 +6963,10 @@ List<SaycRule>? saycRulesForAuction(List<BidAction> calls) {
       }
       if (last == null) return null;
       if (action.bidType == BidType.double) {
+        if (openBid.trump == null && openBid.count == 1) {
+          // Partner's double of their 1NT opening is penalty, not takeout.
+          return oneNtDoubleAdvanceRules(last == openBid ? null : last);
+        }
         return advanceDoubleRules(
             openBid, last, calls[n - 1].bidType == BidType.pass,
             redoubled: calls[n - 1].bidType == BidType.redouble);

--- a/test/bridge/sayc_bidding_test.dart
+++ b/test/bridge/sayc_bidding_test.dart
@@ -1474,6 +1474,34 @@ void main() {
           "6S"); // 2 + 1 aces
     });
 
+    test("penalty double of a 1NT opening", () {
+      // 15+ doubles for penalty; below that, pass or the natural overcall.
+      expect(openingBid("AQ87", "KJ4", "AQ92", "K3", history: ["1NT"]), "Double");
+      expect(openingBid("AQ8", "KJ4", "A952", "J32", history: ["1NT"]), "Double");
+      expect(openingBid("AQ8", "KJ4", "A952", "T32", history: ["1NT"]),
+          "Pass");
+      // With 15+ the double takes priority over the 6-card overcall.
+      expect(openingBid("AQ", "KJ4", "QT9752", "K3", history: ["1NT"]), "Double");
+      // Balancing seat plays the same way.
+      expect(openingBid("AQ87", "KJ4", "AQ92", "K3",
+              history: ["1NT", "pass", "pass"]),
+          "Double");
+    });
+
+    test("advancing the penalty double of 1NT", () {
+      // Manual-play hand: the forced advance scrambled to 2C as if the
+      // double were takeout; passing to defend is the default.
+      final h = ["1NT", "X", "pass"];
+      expect(openingBid("T62", "K93", "KT8", "9876", history: h), "Pass");
+      expect(openingBid("K9765", "T3", "862", "A32", history: h), "Pass");
+      // Only a bust with a 5+ suit pulls.
+      expect(openingBid("97652", "T3", "862", "432", history: h), "2S");
+      // If they run, double the runout for penalty with trumps and values.
+      final run = ["1NT", "X", "2H"];
+      expect(openingBid("T62", "KQ93", "KT8", "A87", history: run), "Double");
+      expect(openingBid("T62", "9873", "KT8", "987", history: run), "Pass");
+    });
+
     test("raises keep their meanings", () {
       expect(openingBid("432", "K32", "KQ32", "432", history: ["1H", "1S"]),
           "2H");


### PR DESCRIPTION
Double with 15+ points, partner normally passes for penalty but will bid a 5+ card suit with a weak hand to avoid defending 1NT doubled when the opener is likely to make it.